### PR TITLE
Fix: add worker-src to CSP for avatar Web Worker

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.nal.usda.gov; img-src 'self' data: https:; frame-ancestors 'none';" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.nal.usda.gov; img-src 'self' data: https:; frame-ancestors 'none';" }
       ]
     }
   ],


### PR DESCRIPTION
## Root cause
The Content-Security-Policy header in `vercel.json` was missing a `worker-src` directive. Per the CSP spec, when `worker-src` is absent the browser falls back to `script-src` for Worker/SharedWorker URLs. The current `script-src` is `'self' 'unsafe-inline' https://fonts.googleapis.com` — no `blob:`. The avatar creation flow spawns a Web Worker from a `blob:` URL, so it was being blocked silently in production.

## Fix
Add `worker-src 'self' blob:;` to the CSP. Surgical — one directive added, nothing else touched.

### vercel.json diff
```diff
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.nal.usda.gov; img-src 'self' data: https:; frame-ancestors 'none';" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.nal.usda.gov; img-src 'self' data: https:; frame-ancestors 'none';" }
```

## Preview
- URL: https://healtho-git-hotfix-csp-worker-src-ayushkapoor11s-projects.vercel.app
- Vercel deployment: \`dpl_n6Q21e9TxTLEzmRoeXzrqTosB2Ce\` — READY
- Header verified live: \`curl -sI\` on the preview returns the CSP with \`worker-src 'self' blob:\` present, all other directives byte-identical to production.

## Verification needed (auth-gated, leaving to reviewer)
- [ ] Sign in on the preview URL
- [ ] Trigger the avatar creation flow → confirm avatar generates
- [ ] Browser console shows no CSP violation for \`blob:\`
- [ ] Spot-check: login, dashboard, food log all still work

## Scope
No other CSP directives or response headers were modified. No code, dependency, or lockfile changes — `vercel.json` only.