### PR TITLE
Phase 3a: read-only display components reskin (CalorieRing, WaterTracker, MealSection)

### DIFF
--- a/apps/web/src/components/CalorieRing.jsx
+++ b/apps/web/src/components/CalorieRing.jsx
@@ -1,87 +1,276 @@
-// CalorieRing — animated SVG donut showing calorie progress
-// Props: consumed, goal, burned
+import { useEffect, useRef, useState } from 'react'
+import { Card } from '@healtho/ui'
+
+// CalorieRing — animated SVG donut showing calorie progress.
+//
+// Visual spec: project/preview/comp-calorie-ring.html (160×160 ring,
+// remaining-first visualization where the gradient arc represents
+// REMAINING calories, with an inner hairline arc showing consumed for
+// context). Tick marks at 12 / 3 / 6 / 9 o'clock. Decorative glow blobs
+// in opposite corners.
+//
+// Behavioral preservation: same prop signature (consumed, goal, burned)
+// and same `remaining = goal - consumed + burned` math, including the
+// "burned exercise calories add back to remaining" rule from the
+// pre-Phase-3 implementation.
+//
+// Reward state: when consumed transitions from < goal to >= goal, the
+// center number runs the rewardPop keyframe (defined in @healtho/ui
+// tokens.css) once. The arc shifts to brand-green and the "Remaining"
+// label flips to "Goal met". prefers-reduced-motion zeroes the duration
+// via the --dur-reward token.
 export default function CalorieRing({ consumed = 0, goal = 0, burned = 0 }) {
-  const remaining  = Math.max(goal - consumed + burned, 0)
-  const pct        = Math.min(consumed / goal, 1)
-  const circumference = 339.3
-  const offset     = circumference - pct * circumference
+  const remaining     = Math.max(goal - consumed + burned, 0)
+  const remainingFrac = goal > 0 ? Math.min(remaining / goal, 1) : 0
+  const consumedFrac  = goal > 0 ? Math.min(consumed / goal, 1) : 0
+  const burnedFrac    = goal > 0 ? Math.min(burned   / goal, 1) : 0
+
+  const isMet = goal > 0 && consumed >= goal
+  const isLow = goal > 0 && remainingFrac < 0.15 && !isMet
+
+  // Outer arc — remaining as a fraction of the goal, sweeping from 12 o'clock
+  const C_OUTER   = 2 * Math.PI * 60                  // ≈ 376.99
+  const outerDash = C_OUTER * remainingFrac
+  const outerGap  = C_OUTER - outerDash
+
+  // Inner arc — consumed for context (hairline)
+  const C_INNER   = 2 * Math.PI * 46                  // ≈ 289.03
+  const innerDash = C_INNER * consumedFrac
+  const innerGap  = C_INNER - innerDash
+
+  // Reward animation — fires once per goal-met transition
+  const [showReward, setShowReward] = useState(false)
+  const wasMetRef = useRef(false)
+  useEffect(() => {
+    if (isMet && !wasMetRef.current) {
+      setShowReward(true)
+      wasMetRef.current = true
+      const t = setTimeout(() => setShowReward(false), 1000)
+      return () => clearTimeout(t)
+    }
+    if (!isMet) wasMetRef.current = false
+  }, [isMet])
+
+  // Color tokens for the three states
+  const arcStroke   = isMet ? '#4caf7d' : `url(#cr-${isLow ? 'amber' : 'brand'})`
+  const trackStroke = isMet ? 'rgba(76,175,125,0.18)' : '#1a1640'
+  const arcShadow   = isMet
+    ? 'drop-shadow(0 0 8px rgba(76,175,125,0.55))'
+    : isLow
+      ? 'drop-shadow(0 0 6px rgba(232,180,75,0.5))'
+      : 'drop-shadow(0 0 10px rgba(139,92,246,0.55))'
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 relative overflow-hidden">
-      {/* Glow blob */}
-      <div className="absolute -top-10 -right-10 w-40 h-40 rounded-full bg-primary/5 blur-2xl pointer-events-none" />
+    <Card padding="lg">
+      {/* Decorative glow blobs — pink top-right, cyan bottom-left */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-[60px] -right-[40px] w-[220px] h-[220px] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgba(232,121,249,0.14), transparent 70%)',
+          filter: 'blur(30px)',
+        }}
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-[60px] -left-[40px] w-[180px] h-[180px] rounded-full"
+        style={{
+          background: 'radial-gradient(circle, rgba(34,211,238,0.10), transparent 70%)',
+          filter: 'blur(30px)',
+        }}
+      />
 
-      <div className="flex items-center gap-6">
-        {/* Ring */}
-        <div className="relative flex-shrink-0">
-          <svg width="130" height="130" viewBox="0 0 130 130" style={{ transform: 'rotate(-90deg)' }}>
-            <circle cx="65" cy="65" r="54" fill="none" stroke="#1a1640" strokeWidth="11" />
-            <circle
-              cx="65" cy="65" r="54"
-              fill="none"
-              stroke="url(#ringGradient)"
-              strokeWidth="11"
-              strokeLinecap="round"
-              strokeDasharray={circumference}
-              strokeDashoffset={offset}
-              className="ring-animate"
-              style={{ filter: 'drop-shadow(0 0 8px rgba(139,92,246,0.5))' }}
-            />
+      <div className="relative flex items-center gap-6">
+        {/* RING */}
+        <div className="relative w-40 h-40 flex-shrink-0">
+          {/* Tick marks at 12 / 3 / 6 / 9 */}
+          <svg className="absolute inset-0" width="160" height="160" viewBox="0 0 160 160">
+            <g transform="translate(80 80)" stroke="#2a2447" strokeWidth="1.5" strokeLinecap="round">
+              <line x1="0"   y1="-72" x2="0"   y2="-66" />
+              <line x1="72"  y1="0"   x2="66"  y2="0"   />
+              <line x1="0"   y1="72"  x2="0"   y2="66"  />
+              <line x1="-72" y1="0"   x2="-66" y2="0"   />
+            </g>
+          </svg>
+
+          {/* Track ring */}
+          <svg
+            className="absolute inset-0"
+            width="160" height="160" viewBox="0 0 160 160"
+            style={{ transform: 'rotate(-90deg)' }}
+          >
+            <circle cx="80" cy="80" r="60" fill="none" stroke={trackStroke} strokeWidth="10" />
+          </svg>
+
+          {/* Remaining arc — gradient stroke, sweeps from 12 o'clock */}
+          <svg
+            className="absolute inset-0"
+            width="160" height="160" viewBox="0 0 160 160"
+            style={{ transform: 'rotate(-90deg)' }}
+          >
             <defs>
-              <linearGradient id="ringGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+              <linearGradient id="cr-brand" x1="0%" y1="0%" x2="100%" y2="0%">
                 <stop offset="0%"   stopColor="#e879f9" />
                 <stop offset="50%"  stopColor="#8b5cf6" />
                 <stop offset="100%" stopColor="#22d3ee" />
               </linearGradient>
+              <linearGradient id="cr-amber" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%"   stopColor="#f59e0b" />
+                <stop offset="100%" stopColor="#e8b84b" />
+              </linearGradient>
             </defs>
+            {goal > 0 && (
+              <circle
+                cx="80" cy="80" r="60"
+                fill="none" stroke={arcStroke} strokeWidth="10" strokeLinecap="round"
+                strokeDasharray={`${outerDash} ${outerGap}`}
+                strokeDashoffset="0"
+                className="transition-all duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]"
+                style={{ filter: arcShadow }}
+              />
+            )}
           </svg>
-          <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
-            <span className="font-mono text-3xl font-bold text-white leading-none">{remaining.toLocaleString()}</span>
-            <span className="text-slate-500 text-[10px] font-semibold uppercase tracking-wider mt-1">remaining</span>
+
+          {/* Consumed inner arc — hairline context */}
+          <svg
+            className="absolute inset-0"
+            width="160" height="160" viewBox="0 0 160 160"
+            style={{ transform: 'rotate(-90deg)' }}
+          >
+            <circle cx="80" cy="80" r="46" fill="none" stroke="#1e293b" strokeWidth="3" />
+            {goal > 0 && consumed > 0 && (
+              <circle
+                cx="80" cy="80" r="46"
+                fill="none" stroke="rgba(255,255,255,0.35)" strokeWidth="3" strokeLinecap="round"
+                strokeDasharray={`${innerDash} ${innerGap}`}
+                strokeDashoffset="0"
+                className="transition-all duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]"
+              />
+            )}
+          </svg>
+
+          {/* Center — remaining number, kcal unit, label */}
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center"
+            style={
+              showReward
+                ? { animation: 'rewardPop var(--dur-reward) var(--ease-spring) both' }
+                : undefined
+            }
+          >
+            <span
+              className={`font-mono text-[34px] font-bold leading-none tracking-tight ${
+                isMet ? 'text-fiber' : 'text-white'
+              }`}
+            >
+              {remaining.toLocaleString()}
+            </span>
+            <span className="text-[10px] text-slate-400 mt-0.5 font-display">kcal</span>
+            <span
+              className={`text-[9px] font-bold uppercase tracking-[0.14em] mt-1 font-display ${
+                isMet ? 'text-fiber' : 'text-slate-500'
+              }`}
+            >
+              {isMet ? 'Goal met' : 'Remaining'}
+            </span>
           </div>
         </div>
 
-        {/* Stats */}
-        <div className="flex-1 space-y-3">
-          <div>
-            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider">Consumed</p>
-            <p className="font-mono text-2xl font-bold text-white">{consumed.toLocaleString()} <span className="text-sm text-slate-500 font-normal">kcal</span></p>
-          </div>
-          <div className="h-px bg-slate-800" />
-          {/* Daily Goal — ? tooltip uses CSS group-hover (matches streak tooltip pattern) */}
-          <div className="relative group/goal">
-            <div className="flex items-center gap-1.5">
-              <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider">Daily Goal</p>
-              <button
-                type="button"
-                aria-label="Calculation details"
-                aria-describedby="goal-tooltip"
-                className="w-4 h-4 rounded-full border border-slate-600 flex items-center justify-center text-slate-500 hover:text-primary hover:border-primary focus:text-primary focus:border-primary transition-colors outline-none"
-              >
-                <span className="text-[9px] font-bold leading-none">?</span>
-              </button>
-            </div>
-            <p className="font-mono text-2xl font-bold text-white">{goal.toLocaleString()} <span className="text-sm text-slate-500 font-normal">kcal</span></p>
+        {/* STATS */}
+        <div className="flex-1 flex flex-col gap-0.5">
+          <StatRow
+            label="Consumed"
+            value={consumed.toLocaleString()}
+            unit="kcal"
+            dotStyle={{ background: 'rgba(255,255,255,0.35)' }}
+            barFrac={consumedFrac}
+            barStyle={{ background: 'rgba(255,255,255,0.6)' }}
+          />
+          <Sep />
+          <StatRow
+            label="Daily goal"
+            value={goal.toLocaleString()}
+            unit="kcal"
+            dotStyle={{ background: 'linear-gradient(135deg,#e879f9,#8b5cf6,#22d3ee)' }}
+            barFrac={1}
+            barStyle={{ background: 'linear-gradient(90deg,#e879f9,#8b5cf6,#22d3ee)' }}
+            labelExtra={<DailyGoalInfo />}
+          />
+          <Sep />
+          <StatRow
+            label="Burned"
+            value={burned.toLocaleString()}
+            unit="kcal"
+            dotStyle={{ background: '#334155' }}
+            barFrac={burnedFrac}
+            barStyle={{ background: '#475569' }}
+          />
+        </div>
+      </div>
+    </Card>
+  )
+}
 
-            {/* Tooltip — CSS-only, visible on hover/focus within the group */}
-            <div
-              id="goal-tooltip"
-              role="tooltip"
-              className="absolute bottom-full left-0 right-0 mb-2 z-50 pointer-events-none
-                         opacity-0 group-hover/goal:opacity-100 group-focus-within/goal:opacity-100 transition-opacity duration-200"
-            >
-              <div className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 shadow-xl w-fit">
-                <p className="text-xs text-slate-300 font-medium whitespace-nowrap">How we calculate your Daily Goal</p>
-                <p className="text-[10px] text-slate-500 mt-0.5 whitespace-nowrap">BMR × activity level ± fitness goal</p>
-              </div>
-              <div className="w-2 h-2 bg-slate-800 border-r border-b border-slate-700 rotate-45 ml-[4.5rem] -mt-1" />
-            </div>
+function Sep() {
+  return <div className="h-px bg-slate-800" />
+}
+
+function StatRow({ label, labelExtra, value, unit, dotStyle, barFrac, barStyle }) {
+  return (
+    <div className="flex items-center gap-[10px] py-[10px]">
+      <div className="w-2 h-2 rounded-sm flex-shrink-0" style={dotStyle} />
+      <div className="flex-1 flex items-center gap-3 min-w-0">
+        <div className="flex flex-col min-w-[110px]">
+          <div className="flex items-center gap-1.5">
+            <p className="text-[9px] font-bold uppercase tracking-[0.12em] text-slate-500 font-display">
+              {label}
+            </p>
+            {labelExtra}
           </div>
-          <div className="h-px bg-slate-800" />
-          <div>
-            <p className="text-slate-500 text-xs font-semibold uppercase tracking-wider">Exercise Burned</p>
-            <p className="font-mono text-2xl font-bold text-white">{burned.toLocaleString()} <span className="text-sm text-slate-500 font-normal">kcal</span></p>
-          </div>
+          <p className="font-mono text-lg font-bold text-white leading-tight mt-0.5">
+            {value}{' '}
+            <span className="font-display text-[11px] font-normal text-slate-500">{unit}</span>
+          </p>
+        </div>
+        <div className="flex-1 h-1 rounded-full bg-slate-800 overflow-hidden ml-2">
+          <div
+            className="h-full rounded-full transition-all duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]"
+            style={{ width: `${Math.min(barFrac * 100, 100)}%`, ...barStyle }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Tooltip preserved from the pre-Phase-3 CalorieRing — surfaces the
+// "BMR × activity ± fitness goal" calculation explanation. Spec doesn't
+// call for it; we keep it because it's an accessibility-positive
+// affordance and the user explicitly said "every prop, every callback,
+// every data-flow contract stays the same."
+function DailyGoalInfo() {
+  return (
+    <div className="relative group/info">
+      <button
+        type="button"
+        aria-label="Calculation details"
+        aria-describedby="cr-goal-tooltip"
+        className="w-3.5 h-3.5 rounded-full border border-slate-600 flex items-center justify-center text-slate-500 hover:text-primary hover:border-primary focus:text-primary focus:border-primary transition-colors outline-none"
+      >
+        <span className="text-[8px] font-bold leading-none">?</span>
+      </button>
+      <div
+        id="cr-goal-tooltip"
+        role="tooltip"
+        className="absolute bottom-full left-0 mb-2 z-50 pointer-events-none opacity-0 group-hover/info:opacity-100 group-focus-within/info:opacity-100 transition-opacity duration-200"
+      >
+        <div className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 shadow-xl w-fit">
+          <p className="text-xs text-slate-300 font-medium whitespace-nowrap font-display">
+            How we calculate your Daily Goal
+          </p>
+          <p className="text-[10px] text-slate-500 mt-0.5 whitespace-nowrap font-display">
+            BMR × activity level ± fitness goal
+          </p>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/MealSection.jsx
+++ b/apps/web/src/components/MealSection.jsx
@@ -1,12 +1,30 @@
 import { useState } from 'react'
+import { MaterialIcon } from '@healtho/ui'
 
-export default function MealSection({ emoji, name, calories = 0, items = [], defaultOpen = false, onAdd, onDelete, onEdit }) {
-  const [open,          setOpen]          = useState(defaultOpen)
-  const [confirmId,     setConfirmId]     = useState(null)  // id of item pending delete confirm
+// MealSection — collapsible meal row with item list and inline add.
+//
+// Visual spec: project/preview/comp-meal-section.html. The
+// pre-Phase-3 implementation already matches the spec structurally;
+// the only change here is swapping raw `<span class="material-symbols-outlined">`
+// for the MaterialIcon primitive so iconography goes through a single
+// (XSS-safe) source.
+//
+// Behavioral preservation: same props, same delete-confirm flow,
+// same edit/delete callbacks.
+export default function MealSection({
+  emoji,
+  name,
+  calories = 0,
+  items = [],
+  defaultOpen = false,
+  onAdd,
+  onDelete,
+  onEdit,
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  const [confirmId, setConfirmId] = useState(null)  // id of item pending delete confirm
 
-  const handleDeleteClick = (id) => {
-    setConfirmId(id)   // first click → show confirm
-  }
+  const handleDeleteClick = (id) => setConfirmId(id)
   const handleDeleteConfirm = (id) => {
     setConfirmId(null)
     onDelete?.(id)
@@ -14,47 +32,60 @@ export default function MealSection({ emoji, name, calories = 0, items = [], def
 
   return (
     <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-4 cursor-pointer select-none" onClick={() => setOpen(o => !o)}>
-        <div className="w-10 h-10 rounded-xl bg-slate-800 flex items-center justify-center text-xl flex-shrink-0">{emoji}</div>
+      <div
+        className="flex items-center gap-3 px-4 py-4 cursor-pointer select-none"
+        onClick={() => setOpen(o => !o)}
+      >
+        <div className="w-10 h-10 rounded-xl bg-slate-800 flex items-center justify-center text-xl flex-shrink-0">
+          {emoji}
+        </div>
         <div className="flex-1">
           <p className="text-sm font-bold text-white">{name}</p>
           <p className="text-xs text-slate-500 mt-0.5">
-            {items.length > 0
-              ? <>
-                  <span className="text-slate-300 font-semibold">{calories}</span> kcal
-                  {calories === 0 && items.length > 0 && (
-                    <span className="text-slate-600"> (0 cal items)</span>
-                  )}
-                  {' · '}{items.length} item{items.length !== 1 ? 's' : ''}
-                </>
-              : 'Not logged yet'
-            }
+            {items.length > 0 ? (
+              <>
+                <span className="text-slate-300 font-semibold">{calories}</span> kcal
+                {calories === 0 && items.length > 0 && (
+                  <span className="text-slate-600"> (0 cal items)</span>
+                )}
+                {' · '}{items.length} item{items.length !== 1 ? 's' : ''}
+              </>
+            ) : (
+              'Not logged yet'
+            )}
           </p>
         </div>
         <button
+          type="button"
+          aria-label={`Add to ${name}`}
           className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10 text-primary hover:bg-primary hover:text-white transition-all text-lg font-light flex-shrink-0"
           onClick={(e) => { e.stopPropagation(); onAdd?.() }}
         >+</button>
-        <span
-          className="material-symbols-outlined text-slate-600 text-lg ml-1 transition-transform duration-200 flex-shrink-0"
+        <MaterialIcon
+          name="expand_more"
+          size={20}
+          className="text-slate-600 ml-1 transition-transform duration-200 flex-shrink-0"
           style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)' }}
-        >expand_more</span>
+        />
       </div>
 
       {open && (
         <div className="border-t border-slate-800 px-4 pb-4 pt-3 space-y-2">
           {items.length > 0 ? items.map(item => (
             <div key={item.id}>
-              {/* Delete confirmation row */}
               {confirmId === item.id ? (
                 <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/30 rounded-xl px-3 py-2">
-                  <span className="material-symbols-outlined text-red-400 text-sm">warning</span>
-                  <p className="text-xs text-red-400 font-semibold flex-1">Delete "{item.name}"?</p>
+                  <MaterialIcon name="warning" size={14} className="text-red-400" />
+                  <p className="text-xs text-red-400 font-semibold flex-1">
+                    Delete &quot;{item.name}&quot;?
+                  </p>
                   <button
+                    type="button"
                     onClick={() => handleDeleteConfirm(item.id)}
                     className="text-xs font-bold text-red-400 hover:text-red-300 px-2 py-1 rounded-lg hover:bg-red-500/20 transition-colors"
                   >Yes, delete</button>
                   <button
+                    type="button"
                     onClick={() => setConfirmId(null)}
                     className="text-xs font-bold text-slate-400 hover:text-white px-2 py-1 rounded-lg hover:bg-slate-800 transition-colors"
                   >Cancel</button>
@@ -64,27 +95,31 @@ export default function MealSection({ emoji, name, calories = 0, items = [], def
                   <div className="w-1.5 h-1.5 rounded-full bg-slate-700 flex-shrink-0" />
                   <p className="text-sm text-slate-300 flex-1">{item.name}</p>
                   <p className="text-xs text-slate-600">{item.portion}</p>
-                  <span className="font-mono text-xs bg-slate-800 text-slate-300 px-2 py-0.5 rounded-full">{item.calories} kcal</span>
+                  <span className="font-mono text-xs bg-slate-800 text-slate-300 px-2 py-0.5 rounded-full">
+                    {item.calories} kcal
+                  </span>
 
-                  {/* Edit button */}
                   {onEdit && (
                     <button
+                      type="button"
                       onClick={() => onEdit(item)}
+                      aria-label={`Edit ${item.name}`}
                       className="opacity-30 group-hover:opacity-100 text-slate-400 hover:text-primary transition-all"
                       title="Edit serving"
                     >
-                      <span className="material-symbols-outlined text-base">edit</span>
+                      <MaterialIcon name="edit" size={16} />
                     </button>
                   )}
 
-                  {/* Delete button — subtle always-visible, full opacity on hover */}
                   {onDelete && (
                     <button
+                      type="button"
                       onClick={() => handleDeleteClick(item.id)}
+                      aria-label={`Delete ${item.name}`}
                       className="opacity-30 group-hover:opacity-100 text-slate-600 hover:text-red-400 transition-all"
                       title="Delete entry"
                     >
-                      <span className="material-symbols-outlined text-base">delete</span>
+                      <MaterialIcon name="delete" size={16} />
                     </button>
                   )}
                 </div>

--- a/apps/web/src/components/WaterTracker.jsx
+++ b/apps/web/src/components/WaterTracker.jsx
@@ -1,14 +1,31 @@
 import { useState, useEffect } from 'react'
+import { Card, Badge, MaterialIcon } from '@healtho/ui'
 
-const TOTAL_DOTS   = 8
-const ML_PER_DOT   = 2500 / 8   // 312.5 ml per dot
-const STORAGE_KEY  = 'healtho_water_manual'
+const TOTAL_GLASSES = 8
+const ML_PER_GLASS  = 2500 / 8   // 312.5 ml per glass
+const STORAGE_KEY   = 'healtho_water_manual'
 
 // Local date string (YYYY-MM-DD) in user's timezone — same helper as Dashboard
 const localDateStr = (d = new Date()) =>
   `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 
-export default function WaterTracker({ waterLevel = 0, goalMet = false, onLevelChange, isToday = true }) {
+// WaterTracker — daily hydration display, 8 glasses (2.5 L total).
+//
+// Visual spec: project/preview/comp-water-tracker.html (SVG glass
+// silhouettes with gradient water fill, hover lift, goal-met state
+// with cyan glow border). The pre-Phase-3 implementation used 8 dots;
+// this reskin replaces them with proper glasses.
+//
+// Behavioral preservation: same prop signature (waterLevel, goalMet,
+// onLevelChange, isToday). Same logic for: localStorage manual override,
+// past-date read-only mode, reset button availability, parent
+// onLevelChange notification.
+export default function WaterTracker({
+  waterLevel = 0,
+  goalMet = false,
+  onLevelChange,
+  isToday = true,
+}) {
   // waterLevel  — float 0–8 driven by food_logs (logged drinks) — persists via DB
   // manualDots  — integer 0–8 set by tapping — persists via localStorage (date-keyed)
   //               Only used for today. Past dates show logged water only.
@@ -19,89 +36,173 @@ export default function WaterTracker({ waterLevel = 0, goalMet = false, onLevelC
     } catch { return 0 }
   })
 
-  // Persist manual dots to localStorage whenever they change
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({ date: localDateStr(), dots: manualDots }))
     } catch { /* localStorage unavailable — silently ignore */ }
   }, [manualDots])
 
-  // Past dates: only show logged water level, ignore manual dots
   const totalLevel = isToday
-    ? Math.min(TOTAL_DOTS, Math.max(waterLevel, manualDots))
-    : Math.min(TOTAL_DOTS, waterLevel)
-  const liters = ((totalLevel * ML_PER_DOT) / 1000).toFixed(1)
+    ? Math.min(TOTAL_GLASSES, Math.max(waterLevel, manualDots))
+    : Math.min(TOTAL_GLASSES, waterLevel)
+  const liters = ((totalLevel * ML_PER_GLASS) / 1000).toFixed(1)
+  const wholeGlasses = Math.floor(totalLevel)
+  const halfFraction = totalLevel - wholeGlasses
+  const countLabel = halfFraction >= 0.25 && halfFraction < 0.75
+    ? `${wholeGlasses}½`
+    : `${Math.round(totalLevel)}`
 
-  // Notify parent of level changes (for celebration triggers)
   useEffect(() => {
     onLevelChange?.(totalLevel)
   }, [totalLevel, onLevelChange])
 
-  const handleDot = (idx) => {
-    if (!isToday) return // read-only on past dates
+  const handleGlass = (idx) => {
+    if (!isToday) return
     const desired = idx < totalLevel ? idx : idx + 1  // toggle: unfill to idx, or fill to idx+1
     if (desired <= waterLevel) {
-      // Can't go below logged level — reset manual so waterLevel takes over naturally
       setManualDots(0)
     } else {
-      // Desired level is above logged water — store as manual override
       setManualDots(desired)
     }
   }
 
-  // Can manual dots be reduced? (only when manualDots > waterLevel floor, today only)
   const canReset = isToday && manualDots > 0 && manualDots > Math.ceil(waterLevel)
 
-  // Subtitle text
-  const subtitle = isToday
-    ? `${liters} / 2.5 L — tap to update`
-    : totalLevel > 0
-      ? `${liters} / 2.5 L logged`
-      : 'No water logged this day'
-
   return (
-    <div className={`bg-slate-900 border border-slate-800 rounded-xl p-4 flex items-center gap-4 transition-all duration-500${goalMet ? ' water-goal-glow' : ''}`}>
-      <div className="w-10 h-10 rounded-xl bg-slate-800 flex items-center justify-center flex-shrink-0">
-        <span className="material-symbols-outlined text-water text-xl">water_drop</span>
-      </div>
-      <div className="flex-1">
-        <p className="text-sm font-bold text-white">Water Intake</p>
-        <p className="text-xs text-slate-500 mt-0.5">
-          {subtitle}
-          {canReset && (
-            <button
-              onClick={() => setManualDots(Math.ceil(waterLevel))}
-              className="ml-2 text-water/70 hover:text-water underline transition-colors"
-            >
-              Reset
-            </button>
-          )}
-        </p>
-      </div>
-      <div className="flex gap-1.5">
-        {Array.from({ length: TOTAL_DOTS }).map((_, i) => {
-          const fillFrac = Math.min(1, Math.max(0, totalLevel - i))
-          const fillPct  = Math.round(fillFrac * 100)
-          const isEmpty  = fillPct === 0
+    <Card
+      padding="md"
+      className={`transition-all duration-500 ${
+        goalMet
+          ? 'border-water/[0.55] shadow-[0_0_35px_rgba(96,184,212,0.22),inset_0_0_30px_rgba(96,184,212,0.06)]'
+          : ''
+      }`}
+      style={
+        goalMet
+          ? { background: 'linear-gradient(135deg, rgba(96,184,212,0.08), #0e0b1e)' }
+          : undefined
+      }
+    >
+      {/* Decorative glow blob */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-[60px] -right-[40px] w-[220px] h-[220px] rounded-full"
+        style={{
+          background: `radial-gradient(circle, rgba(96,184,212,${goalMet ? 0.25 : 0.14}), transparent 70%)`,
+          filter: 'blur(30px)',
+        }}
+      />
 
+      {/* Hidden defs — gradient + clipPath shared across all glass SVGs */}
+      <svg width="0" height="0" className="absolute pointer-events-none" aria-hidden="true">
+        <defs>
+          <linearGradient id="wt-water" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%"   stopColor="#60b8d4" />
+            <stop offset="100%" stopColor="#22d3ee" />
+          </linearGradient>
+          <clipPath id="wt-clip">
+            <path d="M14 10 Q14 8 16 8 L54 8 Q56 8 56 10 L52 66 Q52 68 50 68 L20 68 Q18 68 18 66 Z" />
+          </clipPath>
+        </defs>
+      </svg>
+
+      {/* Title row */}
+      <div className="relative z-10 flex items-center justify-between mb-5 gap-3">
+        <div className="flex items-center gap-2.5">
+          <MaterialIcon name="water_drop" size={20} className="text-water" />
+          <p className="text-[15px] font-bold text-white tracking-tight font-display">Water</p>
+          {goalMet && <Badge variant="ok" icon="check_circle">Goal met</Badge>}
+        </div>
+        <div className="font-mono text-lg font-bold text-white tracking-tight whitespace-nowrap">
+          {countLabel}
+          <span className="text-slate-400 font-medium font-display">
+            {' '}/ {TOTAL_GLASSES} glasses
+          </span>
+        </div>
+      </div>
+
+      {/* Glasses */}
+      <div className="relative z-10 grid grid-cols-8 gap-[14px] justify-items-center">
+        {Array.from({ length: TOTAL_GLASSES }).map((_, i) => {
+          const fillFrac = Math.min(1, Math.max(0, totalLevel - i))
           return (
-            <button
+            <Glass
               key={i}
-              onClick={() => handleDot(i)}
+              fill={fillFrac}
+              onClick={() => handleGlass(i)}
               disabled={!isToday}
-              className={`relative w-5 h-5 rounded-full border-2 overflow-hidden transition-all${isToday ? ' hover:scale-110 cursor-pointer' : ' cursor-default opacity-60'}`}
-              style={{ borderColor: isEmpty ? '#334155' : '#60b8d4', backgroundColor: '#1e293b' }}
-            >
-              {fillPct > 0 && (
-                <div
-                  className="absolute bottom-0 left-0 right-0 transition-all duration-300"
-                  style={{ height: `${fillPct}%`, backgroundColor: '#60b8d4' }}
-                />
-              )}
-            </button>
+            />
           )
         })}
       </div>
-    </div>
+
+      {/* Subtitle / reset */}
+      <p className="relative z-10 mt-3 text-xs text-slate-500 font-display">
+        {isToday ? `${liters} / 2.5 L — tap a glass to update` :
+          totalLevel > 0 ? `${liters} / 2.5 L logged` : 'No water logged this day'}
+        {canReset && (
+          <button
+            type="button"
+            onClick={() => setManualDots(Math.ceil(waterLevel))}
+            className="ml-2 text-water/70 hover:text-water underline transition-colors"
+          >
+            Reset
+          </button>
+        )}
+      </p>
+    </Card>
+  )
+}
+
+// Glass — tapered tumbler with proportional water fill.
+// fill is 0..1; 0 renders an empty grey outline.
+function Glass({ fill, onClick, disabled }) {
+  const fillPct = Math.round(Math.min(1, Math.max(0, fill)) * 100)
+  const isEmpty = fillPct === 0
+  // Water rect occupies y=6..66 inside the viewBox at 100% fill (60 units of vertical range)
+  const fillTop    = 6 + (1 - fillPct / 100) * 60
+  const fillHeight = (fillPct / 100) * 60
+
+  const stroke = isEmpty ? '#334155' : '#60b8d4'
+  const topFill = isEmpty ? 'rgba(15,23,42,0.6)' : 'rgba(15,23,42,0.4)'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={`Glass ${fillPct === 0 ? 'empty' : fillPct === 100 ? 'full' : `${fillPct}% full`}, tap to ${fillPct === 0 ? 'fill' : 'empty'}`}
+      className={`relative w-[54px] h-[70px] flex-shrink-0 transition-transform duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] ${
+        disabled
+          ? 'cursor-default opacity-60'
+          : 'hover:-translate-y-0.5 cursor-pointer focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)] rounded-md'
+      }`}
+    >
+      <svg viewBox="0 0 70 72" className="w-full h-full" fill="none" aria-hidden="true">
+        {/* Top ellipse (opening) — back fill */}
+        <ellipse cx="35" cy="9" rx="21" ry="4" stroke={stroke} strokeWidth="2" fill={topFill} />
+
+        {/* Water — clipped to glass body shape */}
+        {!isEmpty && (
+          <g clipPath="url(#wt-clip)">
+            <rect x="14" y={fillTop} width="42" height={fillHeight} fill="url(#wt-water)" />
+            {fillPct < 100 && fillPct > 0 && (
+              <ellipse cx="35" cy={fillTop} rx="19" ry="2.5" fill="rgba(255,255,255,0.35)" />
+            )}
+          </g>
+        )}
+
+        {/* Glass body outline */}
+        <path
+          d="M14 10 Q14 8 16 8 L54 8 Q56 8 56 10 L52 66 Q52 68 50 68 L20 68 Q18 68 18 66 Z"
+          stroke={stroke} strokeWidth="2" fill="none"
+        />
+        {/* Top ellipse outline */}
+        <ellipse cx="35" cy="9" rx="21" ry="4" stroke={stroke} strokeWidth="2" fill="none" />
+        {/* Top reflection — only when full */}
+        {fillPct === 100 && (
+          <ellipse cx="35" cy="9" rx="18" ry="3" fill="rgba(255,255,255,0.3)" />
+        )}
+      </svg>
+    </button>
   )
 }

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -526,3 +526,40 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
 - **Sub-branch closed at:** `4e36318` (last commit on `design/02-primitives` before merge).
 - **Process delta vs. Phase 1:** internal PR opened via `gh` this time (installed at end of 2026-04-29 session). Audit trail now lives at GitHub.com/PR#8 in addition to the in-repo log. Remote sub-branch retained (not auto-deleted) for the audit trail; can be cleaned up at the end of the migration.
 - **Next:** Phase 3 starts on `design/03a-readonly-components` (cut off `feature/design-system@4e98a85` and pushed). First sub-PR reskins `MacroCard`, `WaterTracker`, `CalorieRing`, `MealSection` to use the Phase 2 primitives. Sub-PRs 3b (`Header`) and 3c (`CelebrationOverlay`) follow on their own branches.
+
+### Phase 3a — Read-only display components
+
+- **Date:** 2026-04-30
+- **Sub-branch:** `design/03a-readonly-components`
+- **Phase 3a commit:** `9fe6a56 feat(app): Phase 3a — reskin read-only display components to spec`
+- **Files reskinned:**
+  - `apps/web/src/components/CalorieRing.jsx` — substantial visual redesign per `project/preview/comp-calorie-ring.html`. 130×130 → 160×160. **Remaining-first arc**: gradient stroke shows REMAINING calories; inner hairline arc shows consumed for context. Tick marks at 12 / 3 / 6 / 9 o'clock. Pink + cyan glow blobs in opposite corners. Stats now have inline mini progress bars + colored dots. State colors (brand gradient default, amber when remaining < 15%, green when met). **Reward animation**: `rewardPop` keyframe (from `@healtho/ui` tokens.css) fires once per goal-met transition via `useEffect` + transient state. Duration `var(--dur-reward)` honors `prefers-reduced-motion` automatically. Wraps in `Card` primitive. Tooltip preserved on Daily Goal label.
+  - `apps/web/src/components/WaterTracker.jsx` — substantial visual redesign per `project/preview/comp-water-tracker.html`. 8 dots → 8 SVG glasses (tapered tumbler with proportional water gradient fill, surface highlight ellipse on partial fills, top reflection on full glasses, hover lift). Goal-met state: cyan border + cyan glow + linear-gradient bg + `Badge variant="ok" icon="check_circle"`. Title row gains `MaterialIcon` water_drop + "X / 8 glasses" count with proper `½` display. Wraps in `Card` primitive. All localStorage / waterLevel / manual-override / past-date logic preserved verbatim.
+  - `apps/web/src/components/MealSection.jsx` — minimal: swapped 4 raw `<span class="material-symbols-outlined">` instances for the `MaterialIcon` primitive (single XSS-safe icon source). Spec already matched structurally.
+- **Files INTENTIONALLY NOT modified:**
+  - `apps/web/src/components/MacroCard.jsx` — current code byte-matches `project/preview/comp-macrocards.html` spec (slate-900 surface, hairline border, `rounded-xl`, colored dot, label, value/goal, bar). No structural or visual change needed. Logged as no-op-by-design rather than a forced reskin.
+- **Build verification:**
+  - `pnpm build` → green in 3.4 s.
+  - Main bundle: 598.04 kB / 168.89 kB gzip (+6.43 kB vs Phase 2) — Card / Badge / MaterialIcon primitives are now imported by app components on `/dashboard`, so they live in the main bundle instead of the lazy `_design-preview` chunk.
+  - `_design-preview` lazy chunk: 13.68 kB / 4.22 kB gzip (was 15.08 kB) — shrunk because primitives moved out via deduplication.
+  - CSS bundle: 46.83 kB / 9.32 kB gzip (+1.40 kB) — new arbitrary-value Tailwind utilities (`-top-[60px]`, `w-[220px]`, `tracking-[0.14em]`, etc.).
+- **Vercel preview:**
+  - `dpl_9eXL2D3PcUbn2uzWivcr4V5T7PdV` at SHA `9fe6a56` reached READY.
+  - Branch alias (Vercel hashed because branch name is long): `https://healtho-git-design-03a-readonly-479b75-ayushkapoor11s-projects.vercel.app/`
+  - The hostname-gate for `_design-preview` (`startsWith('healtho-git-')`) still passes on the hashed alias.
+- **Security gates:**
+  - `pnpm audit --audit-level=high` → "No known vulnerabilities found".
+  - **Zero new npm deps.** Lockfile unchanged this commit.
+  - **No XSS sinks.** Verified: zero `dangerouslySetInnerHTML`, zero `eval` / `new Function`, zero inline event-handler attribute strings. All event handlers wired through React's synthetic event system. `MaterialIcon` continues to pass icon names as JSX text children.
+  - **Refined secret-scan grep** (`(secret|api[_-]?key|access[_-]?token|bearer)\s*[:=]\s*['"]\S{12,}['"]|password\s*[:=]\s*['"][^'"]{6,}['"]|-----BEGIN\s+(RSA|OPENSSH|PRIVATE)`) → PASS. **First phase using the hardened pattern**; no false positives despite the components touching form state and Input primitive demos.
+  - **Same-origin assets only.** No new external origins.
+  - `vercel.json` — **not touched** (`worker-src` CSP fix already absorbed via sync gate #1).
+  - Supabase RLS / auth / `.env` — **not touched**. CalorieRing / WaterTracker / MealSection don't talk to Supabase directly; they consume props from the Dashboard parent.
+- **Deltas vs. plan:**
+  - **MacroCard left untouched.** Plan listed it as one of four reskins; the comp-macrocards.html spec is already met by the current implementation. Forcing a no-op rewrite would have introduced risk for zero visual gain. Documented above.
+  - **`Card` primitive doesn't expose a `radius` prop.** Spec uses `rounded-xl` (12 px) for tight chip cards (MacroCard, MealSection container) and `rounded-2xl` (16 px) for major data cards (CalorieRing, WaterTracker). I used `Card` for the latter two and kept raw `<div>` for the former. **Pickup for Phase 3.5 or earlier**: extend `Card` with a `radius="xl" | "2xl"` prop so all four cases can consume the primitive consistently. Minor — current Tailwind cascade (no `tailwind-merge`) makes className-based override unreliable.
+  - **Tooltip preserved on `Daily Goal`.** Spec has no tooltip but the pre-Phase-3 `CalorieRing` had a `?` button explaining the BMR × activity ± fitness-goal calculation. Kept it because the user explicitly asked to preserve every prop / callback / data-flow contract; the tooltip is an accessibility-positive affordance whose removal would be a regression. Adapted to the new layout next to the "Daily Goal" stat label.
+  - **`prefers-reduced-motion` already honored** for the rewardPop animation via `var(--dur-reward)` — no extra plumbing needed. The token collapses to 0 ms automatically per `tokens.css`.
+- **Surprises / things to flag:**
+  - **Vercel hashed the branch alias.** Branch name `design/03a-readonly-components` was longer than Vercel's internal limit, so the alias became `healtho-git-design-03a-readonly-479b75-...vercel.app` (a `479b75` hash replaces the rest of the name). The `_design-preview` route's hostname gate (`startsWith('healtho-git-')`) still passes. **Heads-up for Phases 3b, 3c, 4a–4d, 5**: shorter sub-branch names give cleaner aliases. Not a blocker.
+- **Pending:** user visual QA on the preview URL (specifically `/dashboard` logged in for the reskinned components, plus the verification checklist in the PR body), then PR merge into `feature/design-system`, then cut `design/03b-header` for Phase 3b.

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -520,4 +520,9 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
 - **Surprises / things to flag:**
   - **Secret-scan command needs hardening.** Discussed under "Security gates" above. Will affect every future phase that touches form code (Register reskin, LogFoodModal, Profile). Recommended fix: scope the grep to credential-shaped patterns or to env/config file paths. Tracking as a Phase 2.5 chore.
   - **`peerDependenciesMeta` not declared.** Some consumers might prefer `peerDependenciesMeta.react.optional = false`. Skipped because we control all consumers in this monorepo. Re-evaluate if `@healtho/ui` ever publishes externally.
-- **Pending:** user visual QA on the preview URL, then PR merge into `feature/design-system`, then cut `design/03a-readonly-components` for Phase 3.
+- **Visual QA:** PASS. User reviewed `/_design-preview`, approved as-is.
+- **PR:** [#8](https://github.com/healtho-app/healtho/pull/8), merged 2026-04-30 via `gh pr merge --merge` (preserves all sub-branch commits).
+- **Merge SHA into feature branch:** `4e98a85bde5d052e30c633a9755f71856f29b75d` (merge commit on `feature/design-system`).
+- **Sub-branch closed at:** `4e36318` (last commit on `design/02-primitives` before merge).
+- **Process delta vs. Phase 1:** internal PR opened via `gh` this time (installed at end of 2026-04-29 session). Audit trail now lives at GitHub.com/PR#8 in addition to the in-repo log. Remote sub-branch retained (not auto-deleted) for the audit trail; can be cleaned up at the end of the migration.
+- **Next:** Phase 3 starts on `design/03a-readonly-components` (cut off `feature/design-system@4e98a85` and pushed). First sub-PR reskins `MacroCard`, `WaterTracker`, `CalorieRing`, `MealSection` to use the Phase 2 primitives. Sub-PRs 3b (`Header`) and 3c (`CelebrationOverlay`) follow on their own branches.


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Production at `healtho-kohl.vercel.app` stays untouched. Ships on top of the Phase 2 primitives merge `4e98a85`.

## Files reskinned

| File | Change |
|---|---|
| `apps/web/src/components/CalorieRing.jsx` | **Substantial redesign** per `project/preview/comp-calorie-ring.html`. 130×130 → 160×160, remaining-first arc viz, tick marks, glow blobs, stats with mini bars + colored dots, state colors (amber/green), `rewardPop` animation on goal-met transition. Wraps in `Card` primitive. Tooltip preserved. |
| `apps/web/src/components/WaterTracker.jsx` | **Substantial redesign** per `project/preview/comp-water-tracker.html`. 8 dots → 8 SVG glasses with proportional water fill, surface highlight, top reflection on full, hover lift. Goal-met state uses `Badge variant="ok"` + cyan glow border. `MaterialIcon` for water_drop. Wraps in `Card` primitive. |
| `apps/web/src/components/MealSection.jsx` | **Minimal**: swapped 4 raw `material-symbols-outlined` spans for `MaterialIcon` primitive. Spec already matched structurally. |

## Files NOT modified (and why)

- **`apps/web/src/components/MacroCard.jsx`** — current code byte-matches the `comp-macrocards.html` spec. Forcing a rewrite would have introduced risk for zero visual gain. Logged as no-op-by-design.

## Visual QA

🔗 **Preview:** [healtho-git-design-03a-readonly-479b75-ayushkapoor11s-projects.vercel.app](https://healtho-git-design-03a-readonly-479b75-ayushkapoor11s-projects.vercel.app/) (Vercel hashed the alias because the branch name is long)

### Dashboard checklist (log in first, then verify)
- [ ] **CalorieRing** renders at 160×160 with the new remaining-first arc, tick marks at 12/3/6/9, pink + cyan corner glows, inner consumed hairline arc, stats with mini bars
- [ ] **CalorieRing reward animation** — log enough food to push consumed ≥ goal; the center number should run `rewardPop` (scale pop) once, arc shifts to green, label flips from "Remaining" to "Goal met"
- [ ] **CalorieRing low state** — when remaining < 15%, arc shifts to amber gradient
- [ ] **CalorieRing tooltip** — `?` next to "Daily Goal" still surfaces the BMR explanation on hover/focus
- [ ] **WaterTracker glasses** — render proper SVG tumblers, not dots. Tap any glass → fills to that level, water gradient flows up. Empty glasses use slate stroke; full ones use cyan stroke + top reflection ellipse
- [ ] **WaterTracker goal-met** — fill all 8 glasses; container gains cyan glow border + linear-gradient bg, `Goal met` Badge appears next to title
- [ ] **WaterTracker localStorage** — manual taps persist across reload (date-keyed)
- [ ] **MealSection icons** — expand_more chevron, edit, delete, warning all render via `MaterialIcon`. Click chevron → row expands; click trash → confirm row appears
- [ ] **MealSection delete-confirm flow** — preserved from pre-reskin version

### Smoke test (parity with previous Vercel previews)
- [ ] Login → Dashboard works end-to-end
- [ ] Add a food via LogFoodModal → persists, dashboard updates
- [ ] Console clean (vercel.live preview-toolbar CSP block is known noise — ignore)

## Security gates

| Gate | Status | Notes |
|---|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS | No known vulnerabilities |
| Zero new npm deps | ✅ PASS | Lockfile unchanged |
| No XSS sinks | ✅ PASS | Zero dangerouslySetInnerHTML / eval / inline event-handler strings; MaterialIcon passes name as JSX text child |
| Refined secret-scan | ✅ PASS | First phase using the hardened grep (credential-shape patterns + min-length string literals); no false positives despite touching form-adjacent code |
| Same-origin assets only | ✅ PASS | No new external origins |
| `vercel.json` untouched | ✅ PASS | `worker-src` CSP fix already absorbed via sync gate #1 |
| Supabase / `.env` untouched | ✅ PASS | Components consume props from Dashboard parent; no direct Supabase calls |

## Build numbers

- Main bundle: **598.04 kB / 168.89 kB gzip** (+6.43 kB vs Phase 2 — Card/Badge/MaterialIcon now in main bundle since they're used by Dashboard)
- `_design-preview` lazy chunk: **13.68 kB / 4.22 kB gzip** (-1.40 kB vs Phase 2 — primitives moved out via deduplication)
- CSS bundle: **46.83 kB / 9.32 kB gzip** (+1.40 kB for new arbitrary-value utilities)

## Pickups flagged for the master agent

1. **`Card` primitive needs a `radius` prop**. Spec uses 12 px for chip cards (MacroCard, MealSection container) and 16 px for major data cards (CalorieRing, WaterTracker). Currently the primitive hard-codes `rounded-2xl`. Workaround: kept raw `<div>` for the chip cases. Phase 3.5 or earlier: add `radius="xl" | "2xl"` so all four cases consume `Card` consistently.
2. **Shorter sub-branch names from Phase 3b onward.** Vercel hashed `design/03a-readonly-components` to `design-03a-readonly-479b75` because of length limits. Aliases like `design/03b-header` will probably be fine; aliases like `design/03c-celebration-overlay` should be shortened proactively (e.g. `design/03c-celebration`).

## Deltas vs. plan

- **MacroCard intentionally untouched** (already matches spec — see "Files NOT modified" above).
- **Tooltip preserved on `CalorieRing` Daily Goal label** — spec has no tooltip but the pre-Phase-3 component had one explaining the BMR × activity ± fitness-goal calculation. Kept per the user's "behavioral preservation" rule.
- **`prefers-reduced-motion` honored automatically** for `rewardPop` via the `var(--dur-reward)` token (collapses to 0 ms in the tokens.css media query). No extra plumbing.

## Known QA noise (NOT a regression)

The preview console logs a CSP block for `vercel.live/_next-live/feedback/feedback.js` — Vercel preview toolbar, intentionally not fixed (would soften prod CSP). Ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)