### PR TITLE
Phase 3.5: extend Card with radius prop, retrofit MacroCard + MealSection

### DIFF
--- a/apps/web/src/components/MacroCard.jsx
+++ b/apps/web/src/components/MacroCard.jsx
@@ -1,4 +1,6 @@
-// MacroCard — single macro chip with label, amount, optional goal, and progress bar
+import { Card } from '@healtho/ui'
+
+// MacroCard — single macro chip with label, amount, optional goal, and progress bar.
 //
 // Props:
 //   label         — "Protein" | "Carbs" | "Fat" | "Fiber"
@@ -10,6 +12,11 @@
 //   color         — tailwind bg class for the dot + default bar fill
 //   overWarning   — when true AND amount > goal, switch bar + text color to red.
 //                   Only used for carbs & fat (overeating protein/fiber is OK).
+//
+// Wraps the @healtho/ui Card primitive at radius="xl" (12 px) per the
+// chip-card spec in project/preview/comp-macrocards.html. The previous
+// raw <div> implementation has been retired in favor of consuming the
+// primitive consistently.
 export default function MacroCard({
   label,
   amount,
@@ -27,21 +34,23 @@ export default function MacroCard({
   const goalColor = isOver ? 'text-red-400' : 'text-slate-500'
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-xl p-3 space-y-2">
-      <div className="flex items-center gap-1.5">
-        <div className={`w-2 h-2 rounded-full flex-shrink-0 ${color}`} />
-        <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider">{label}</p>
+    <Card padding="sm" radius="xl">
+      <div className="space-y-2">
+        <div className="flex items-center gap-1.5">
+          <div className={`w-2 h-2 rounded-full flex-shrink-0 ${color}`} />
+          <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider">{label}</p>
+        </div>
+        <p className={`font-mono text-sm font-bold ${textColor}`}>
+          {amount}{showGoal ? '' : unit}
+          {showGoal && <span className={`font-normal ${goalColor}`}> / {goal}{unit}</span>}
+        </p>
+        <div className="h-1.5 rounded-full bg-slate-800 overflow-hidden">
+          <div
+            className={`h-full rounded-full ${barColor} transition-all duration-700`}
+            style={{ width: `${Math.min(pct, 100)}%` }}
+          />
+        </div>
       </div>
-      <p className={`font-mono text-sm font-bold ${textColor}`}>
-        {amount}{showGoal ? '' : unit}
-        {showGoal && <span className={`font-normal ${goalColor}`}> / {goal}{unit}</span>}
-      </p>
-      <div className="h-1.5 rounded-full bg-slate-800 overflow-hidden">
-        <div
-          className={`h-full rounded-full ${barColor} transition-all duration-700`}
-          style={{ width: `${Math.min(pct, 100)}%` }}
-        />
-      </div>
-    </div>
+    </Card>
   )
 }

--- a/apps/web/src/components/MealSection.jsx
+++ b/apps/web/src/components/MealSection.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { MaterialIcon } from '@healtho/ui'
+import { Card, MaterialIcon } from '@healtho/ui'
 
 // MealSection — collapsible meal row with item list and inline add.
 //
@@ -31,7 +31,7 @@ export default function MealSection({
   }
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+    <Card padding="none" radius="xl">
       <div
         className="flex items-center gap-3 px-4 py-4 cursor-pointer select-none"
         onClick={() => setOpen(o => !o)}
@@ -130,6 +130,6 @@ export default function MealSection({
           )}
         </div>
       )}
-    </div>
+    </Card>
   )
 }

--- a/apps/web/src/pages/_design-preview.jsx
+++ b/apps/web/src/pages/_design-preview.jsx
@@ -124,6 +124,20 @@ export default function DesignPreview() {
               <p className="label-xs">padding lg</p>
             </Card>
           </div>
+          <Row label="radius">
+            <Card radius="lg" padding="sm" className="min-w-[120px] text-center">
+              <p className="label-xs">lg · 8px</p>
+            </Card>
+            <Card radius="xl" padding="sm" className="min-w-[120px] text-center">
+              <p className="label-xs">xl · 12px</p>
+            </Card>
+            <Card radius="2xl" padding="sm" className="min-w-[120px] text-center">
+              <p className="label-xs">2xl · 16px (default)</p>
+            </Card>
+            <Card radius="none" padding="sm" className="min-w-[120px] text-center">
+              <p className="label-xs">none · flat</p>
+            </Card>
+          </Row>
         </Section>
 
         <Section

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -562,4 +562,23 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
   - **`prefers-reduced-motion` already honored** for the rewardPop animation via `var(--dur-reward)` — no extra plumbing needed. The token collapses to 0 ms automatically per `tokens.css`.
 - **Surprises / things to flag:**
   - **Vercel hashed the branch alias.** Branch name `design/03a-readonly-components` was longer than Vercel's internal limit, so the alias became `healtho-git-design-03a-readonly-479b75-...vercel.app` (a `479b75` hash replaces the rest of the name). The `_design-preview` route's hostname gate (`startsWith('healtho-git-')`) still passes. **Heads-up for Phases 3b, 3c, 4a–4d, 5**: shorter sub-branch names give cleaner aliases. Not a blocker.
-- **Pending:** user visual QA on the preview URL (specifically `/dashboard` logged in for the reskinned components, plus the verification checklist in the PR body), then PR merge into `feature/design-system`, then cut `design/03b-header` for Phase 3b.
+- **Visual QA:** PASS. User reviewed reskins on `/dashboard`, approved as-is.
+- **PR:** [#9](https://github.com/healtho-app/healtho/pull/9), merged 2026-04-30 via `gh pr merge --merge`.
+- **Merge SHA into feature branch:** `1878f636b2406a230f37d1fa48576eb47017971d`.
+- **Sub-branch closed at:** `d49e13a`.
+- **Next:** user requested Phase 3.5 (close pickup #1) before Phase 3b.
+
+### Phase 3.5 — Close pickup #1: extend Card primitive with `radius` prop
+
+- **Date:** 2026-04-30
+- **Sub-branch:** `design/03.5-card-radius` cut from `feature/design-system@1878f63`.
+- **Phase 3.5 commit:** `942acb6 feat(ui): Phase 3.5 — extend Card with radius prop, retrofit MacroCard + MealSection`
+- **Why:** Phase 3a flagged that the `Card` primitive only supported `rounded-2xl` (16 px), so `MacroCard` and `MealSection`'s container kept raw `<div>` shells with `rounded-xl` (12 px) per the chip-card spec. Closing the deviation now while context is fresh, before Phase 3b lands more chip-card consumers (Header notification chip, etc.).
+- **Files modified:**
+  - `packages/ui/components/Card.jsx` — adds `radius` prop with values `"none" | "lg" | "xl" | "2xl"`. Default stays `"2xl"` for backward compat — Phase 2 callers (CalorieRing, WaterTracker via Phase 3a, Modal, all `_design-preview` Card usages) render identically.
+  - `apps/web/src/components/MacroCard.jsx` — wraps content in `<Card padding="sm" radius="xl">`, drops the raw `<div className="bg-slate-900 border ...">` shell. Visual output unchanged — identical surface, border, radius, padding.
+  - `apps/web/src/components/MealSection.jsx` — wraps in `<Card padding="none" radius="xl">` (header + body retain their own padding via inner divs). Visual unchanged.
+  - `apps/web/src/pages/_design-preview.jsx` — adds a `radius` demo row to the Card section showing all four options side-by-side for QA.
+- **Build:** `pnpm build` green in 3.3 s. Main bundle 598.07 kB (essentially unchanged from Phase 3a `598.04 kB`). CSS bundle 46.86 kB (+0.03 kB). `_design-preview` chunk +0.6 kB for the new demo row.
+- **Security gates:** pnpm audit clean, zero new deps, refined secret-scan PASS, no XSS sinks introduced, `vercel.json` not touched.
+- **Pending:** user visual QA on the `/dashboard` (MacroCard renders identically) and `/_design-preview` Card section (new radius row visible). Then merge into `feature/design-system`. Then cut `design/03b-header` for Phase 3b.

--- a/packages/ui/components/Card.jsx
+++ b/packages/ui/components/Card.jsx
@@ -8,7 +8,18 @@ import React from 'react';
  *   default   flat hairline-bordered card.
  *   elevated  same surface + lifted card shadow from --shadow-card token.
  *
- * Padding presets sm/md/lg map to design-system spacing.
+ * Radius:
+ *   2xl  16 px (default) — major data cards: CalorieRing, WaterTracker,
+ *        Dashboard summary tiles, marketing modules.
+ *   xl   12 px           — tight chip cards: MacroCard, MealSection
+ *        container, list-row containers.
+ *   lg   8 px            — pill-like blocks (rare).
+ *   none flat            — when the consumer wants to stack a Card inside
+ *        another rounded surface and let the parent define the radius.
+ *
+ * Padding presets sm/md/lg map to design-system spacing. Use `padding="none"`
+ * for stack-of-rows layouts where children control their own padding (e.g.
+ * MealSection's collapsible header + body sections).
  *
  * `glow` is decorative only; rendered with aria-hidden so screen readers
  * skip it. Pointer events are disabled so it never intercepts clicks.
@@ -26,9 +37,17 @@ const VARIANT_CLASS = {
   elevated: 'bg-slate-900 border border-slate-800 shadow-[var(--shadow-card)]',
 };
 
+const RADIUS_CLASS = {
+  none: 'rounded-none',
+  lg: 'rounded-lg',
+  xl: 'rounded-xl',
+  '2xl': 'rounded-2xl',
+};
+
 export function Card({
   variant = 'default',
   padding = 'md',
+  radius = '2xl',
   glow = false,
   className = '',
   children,
@@ -37,7 +56,8 @@ export function Card({
   return (
     <div
       className={[
-        'relative overflow-hidden rounded-2xl',
+        'relative overflow-hidden',
+        RADIUS_CLASS[radius],
         PADDING_CLASS[padding],
         VARIANT_CLASS[variant],
         className,


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Closes the pickup #1 flagged in PR #9 (Phase 3a).

## What ships

| File | Change |
|---|---|
| `packages/ui/components/Card.jsx` | Adds `radius` prop: `"none" \| "lg" \| "xl" \| "2xl"`. Default stays `"2xl"` (16 px) so existing consumers render identically. |
| `apps/web/src/components/MacroCard.jsx` | Wraps in `<Card padding="sm" radius="xl">`. Drops raw `<div>` shell. Visual unchanged. |
| `apps/web/src/components/MealSection.jsx` | Wraps in `<Card padding="none" radius="xl">`. Header + body retain their own padding via inner divs. Visual unchanged. |
| `apps/web/src/pages/_design-preview.jsx` | Adds a `radius` row to the Card section showing all four options side-by-side. |

## Visual QA

🔗 **Preview** (URL once Vercel build completes — typically 15–60 s after push). The hashed alias pattern: `healtho-git-design-03-5-card-radius-...` or similar.

### Checklist
- [ ] **`/dashboard`** — MacroCard chips (Protein, Carbs, Fat, Fiber) render identically to Phase 3a. Slate-900 surface, hairline border, **12 px radius** (`rounded-xl`), 12 px padding. Bar fills + over-warning red state still work.
- [ ] **`/dashboard`** — MealSection rows render identically. Slate-900 surface, **12 px radius**, expand/collapse works, delete-confirm flow works.
- [ ] **`/_design-preview` Card section** — the new "radius" demo row shows four cards side-by-side: lg (8 px) · xl (12 px) · 2xl (16 px default) · none (flat). Visual differences obvious.
- [ ] **`/_design-preview` Modal section** — modals still render at 16 px radius (default). Nothing else regressed.

## Security gates

| Gate | Status |
|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS |
| Zero new npm deps | ✅ PASS — lockfile unchanged |
| No XSS sinks | ✅ PASS |
| Refined secret-scan | ✅ PASS |
| Same-origin assets | ✅ PASS — no new origins |
| `vercel.json` untouched | ✅ PASS |
| Supabase / `.env` untouched | ✅ PASS |

## Build numbers

- Main bundle: **598.07 kB / 168.95 kB gzip** (+0.03 kB vs Phase 3a — essentially noise)
- `_design-preview` chunk: **14.28 kB / 4.31 kB gzip** (+0.6 kB for the new radius demo row)
- CSS bundle: **46.86 kB / 9.33 kB gzip** (+0.03 kB)

## Why now (vs. waiting for Phase 6 polish)

Closing the deviation while context is fresh costs ~30 min. Letting it ride to Phase 6 means re-loading three files of context, plus risk that Phase 3b/3c/4/5 add more chip-card consumers that pile on raw `<div>` shells. Each new raw shell is a future retrofit. Cheaper to close now.

## Known QA noise

`vercel.live/_next-live/feedback/feedback.js` CSP block on previews — pre-existing, intentionally not fixed (would soften prod CSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)