### PR TITLE
Phase 3b: Header reskin

### DIFF
--- a/apps/web/src/components/Header.jsx
+++ b/apps/web/src/components/Header.jsx
@@ -2,9 +2,26 @@ import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import { useProfile } from '../contexts/ProfileContext'
+import { MaterialIcon } from '@healtho/ui'
 
-export default function Header({ rightLabel, rightTo, rightIcon = 'arrow_forward', showLogout = false }) {
-  const [logoTo, setLogoTo]       = useState('/register')
+// Header — top app bar shared across landing, auth, and authenticated routes.
+//
+// Visual spec: project/ui_kits/app/Primitives.jsx (`AppHeader`) + SKILL.md
+// web-nav rule ("top bar 72px, hover underlines"). The design-system
+// component file is byte-identical to this one; the visual change comes
+// from token adoption (--nav-height, --page-gutter, --tap-ring) and
+// MaterialIcon primitive swaps.
+//
+// Behavioral preservation: every prop and the supabase auth-state listener
+// preserved verbatim. This component renders on every route — a regression
+// here breaks the whole app.
+export default function Header({
+  rightLabel,
+  rightTo,
+  rightIcon = 'arrow_forward',
+  showLogout = false,
+}) {
+  const [logoTo, setLogoTo] = useState('/register')
   const [signingOut, setSigningOut] = useState(false)
   const navigate = useNavigate()
   const { profile } = useProfile()
@@ -34,50 +51,72 @@ export default function Header({ rightLabel, rightTo, rightIcon = 'arrow_forward
   }
 
   return (
-    <header className="flex items-center justify-between border-b border-slate-800 px-6 py-4 lg:px-10">
+    <header
+      className="flex items-center justify-between border-b border-slate-800 bg-background-dark px-[var(--page-gutter)]"
+      style={{ minHeight: 'var(--nav-height)' }}
+    >
       <Link to={logoTo} className="flex items-center gap-2.5 flex-shrink-0">
-        <img src="/healtho-icon.svg" alt="Healtho" className="w-9 h-9 rounded-xl" />
-        <h2 className="text-xl font-bold tracking-tight text-brand-gradient whitespace-nowrap">Healtho</h2>
+        <img src="/healtho-icon.svg" alt="" className="w-9 h-9 rounded-xl" />
+        <h2 className="text-xl font-extrabold tracking-[-0.015em] text-brand-gradient whitespace-nowrap font-display">
+          Healtho
+        </h2>
       </Link>
 
       <div className="flex items-center gap-4">
-        {/* Optional right nav link e.g. "My Profile" */}
+        {/* Optional right nav link e.g. "My Profile" — hover underline per SKILL.md web nav */}
         {rightLabel && rightTo && (
-          <Link to={rightTo} className="flex items-center gap-1.5 text-sm font-semibold text-primary hover:underline">
+          <Link
+            to={rightTo}
+            className="flex items-center gap-1.5 text-sm font-semibold text-primary hover:underline underline-offset-4 decoration-primary/60 font-display focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)] rounded px-1 py-0.5"
+          >
             {rightLabel}
-            <span className="material-symbols-outlined text-base">{rightIcon}</span>
+            <MaterialIcon name={rightIcon} size={16} />
           </Link>
         )}
 
-        {/* Profile avatar — links to profile page */}
+        {/* Profile avatar — links to profile page. 36×36 keeps the touch target
+            comfortable on web (32 px floor) and mobile (48 px target — covered by
+            the surrounding link's hit area). */}
         {profile && (
-          <Link to="/profile" className="flex-shrink-0" title="My Profile">
+          <Link
+            to="/profile"
+            className="flex-shrink-0 rounded-full focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)]"
+            aria-label="My profile"
+            title="My profile"
+          >
             {profile.avatar_url ? (
               <img
                 src={profile.avatar_url}
-                alt={profile.full_name || 'Avatar'}
-                className="w-8 h-8 rounded-full object-cover border border-slate-700 hover:border-primary/60 transition-colors"
+                alt=""
+                className="w-9 h-9 rounded-full object-cover border border-slate-800 hover:border-primary/60 transition-colors"
               />
             ) : (
-              <div className="w-8 h-8 rounded-full bg-primary/20 border border-primary/40 flex items-center justify-center text-xs font-bold text-primary hover:bg-primary/30 transition-colors">
-                {(profile.full_name || '?').split(' ').map(w => w[0]).join('').toUpperCase().slice(0, 2)}
+              <div className="w-9 h-9 rounded-full bg-primary/20 border border-primary/40 flex items-center justify-center text-xs font-bold text-primary hover:bg-primary/30 transition-colors font-display">
+                {(profile.full_name || '?')
+                  .split(' ')
+                  .map((w) => w[0])
+                  .join('')
+                  .toUpperCase()
+                  .slice(0, 2)}
               </div>
             )}
           </Link>
         )}
 
-        {/* Logout button — only shown on protected pages */}
+        {/* Logout — only on protected pages. Icon-only on mobile, icon+text on sm+. */}
         {showLogout && (
           <button
+            type="button"
             onClick={handleLogout}
             disabled={signingOut}
-            className="flex items-center gap-1.5 text-sm font-semibold text-slate-400 hover:text-red-400 transition-colors disabled:opacity-50"
+            aria-label={signingOut ? 'Signing out' : 'Sign out'}
             title="Sign out"
+            className="flex items-center gap-1.5 text-sm font-semibold text-slate-400 hover:text-red-400 transition-colors disabled:opacity-50 font-display focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)] rounded px-1 py-0.5"
           >
             {signingOut ? (
-              <span className="material-symbols-outlined text-base animate-spin">progress_activity</span>
+              <MaterialIcon name="progress_activity" size={18} className="animate-spin" />
             ) : (
-              <span className="material-symbols-outlined text-base">logout</span>
+              <MaterialIcon name="logout" size={18} />
             )}
             <span className="hidden sm:inline">{signingOut ? 'Signing out…' : 'Sign out'}</span>
           </button>

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -581,4 +581,44 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
   - `apps/web/src/pages/_design-preview.jsx` — adds a `radius` demo row to the Card section showing all four options side-by-side for QA.
 - **Build:** `pnpm build` green in 3.3 s. Main bundle 598.07 kB (essentially unchanged from Phase 3a `598.04 kB`). CSS bundle 46.86 kB (+0.03 kB). `_design-preview` chunk +0.6 kB for the new demo row.
 - **Security gates:** pnpm audit clean, zero new deps, refined secret-scan PASS, no XSS sinks introduced, `vercel.json` not touched.
-- **Pending:** user visual QA on the `/dashboard` (MacroCard renders identically) and `/_design-preview` Card section (new radius row visible). Then merge into `feature/design-system`. Then cut `design/03b-header` for Phase 3b.
+- **Visual QA:** PASS. User reviewed `/dashboard` (MacroCard + MealSection identical to Phase 3a) and `/_design-preview` Card section (new radius demo row showing 4 variants). Approved.
+- **PR:** [#10](https://github.com/healtho-app/healtho/pull/10), merged 2026-04-30 via `gh pr merge --merge`.
+- **Merge SHA into feature branch:** `53539f9409c0ddd9a2984ee501f6809493498a1f`.
+- **Sub-branch closed at:** `4a8a97a`.
+- **Next:** user greenlit Phase 3b (Header reskin) immediately after.
+
+### Phase 3b — Header reskin
+
+- **Date:** 2026-04-30
+- **Sub-branch:** `design/03b-header` (short name per the Phase 3a Vercel-hashing learning) cut from `feature/design-system@53539f9`.
+- **Phase 3b commit:** `feat(app): Phase 3b — Header reskin` (SHA appended below post-push).
+- **File modified:** `apps/web/src/components/Header.jsx`.
+- **Visual changes:**
+  - Header height now driven by `--nav-height` token via `style={{ minHeight: 'var(--nav-height)' }}` — yields 72 px on web, 56 px on mobile (per `data-platform="mobile"` swap). Replaces the previous `py-4` (≈56 px).
+  - Horizontal padding now `px-[var(--page-gutter)]` — fluid `clamp(1rem, 4vw, 3rem)` on web. Replaces the previous fixed `px-6 lg:px-10`.
+  - Wordmark: `text-xl font-extrabold tracking-[-0.015em]` — matches Primitives.jsx `AppHeader` spec (was `font-bold tracking-tight`).
+  - Right-link hover-underline pattern per SKILL.md web nav: `hover:underline underline-offset-4 decoration-primary/60`. Same affordance for keyboard users via `focus-visible:shadow-[var(--tap-ring)]`.
+  - Avatar bumped from 32 → 36 px (`w-8 h-8` → `w-9 h-9`) so the avatar visually pairs with the wordmark icon (also 36 px) and matches the Primitives.jsx `AppHeader` round-button right-side affordance size.
+  - Logout button: same icon+text layout, but icon is now via `MaterialIcon` primitive and the focus ring uses the brand `--tap-ring` token.
+  - 3 raw `<span class="material-symbols-outlined">` instances → `MaterialIcon` primitive (rightIcon, logout icon, progress_activity spinner).
+- **Behavior preserved (verified line-by-line):**
+  - All four props (`rightLabel`, `rightTo`, `rightIcon`, `showLogout`) unchanged.
+  - `useEffect` auth-state setup: `getSession` then `onAuthStateChange` subscription, unsubscribe on unmount — verbatim.
+  - `handleLogout` flow: setSigningOut → `supabase.auth.signOut()` → `navigate('/login', { replace: true })` — verbatim.
+  - Logo route logic: `/dashboard` if session, `/login` otherwise — verbatim.
+  - Avatar fallback: `avatar_url` image if present, else two-letter initials from `full_name` — verbatim.
+  - Mobile-hidden "Sign out" text via `hidden sm:inline` — preserved.
+- **Primitives consumed:** `MaterialIcon` (3 usages). `IconButton` / `Badge` / `Card` deliberately NOT used — the rightLabel link has icon+text, the logout has icon+text, the avatar is a `<Link>` wrapping an image/initials, and the header surface is a `<header>` not a card. Forcing a primitive into any of these would create a worse fit than the explicit markup.
+- **Build verification:** `pnpm build` green in 4.0 s. Bundle deltas to be filled in post-build (typical: main bundle within ±1 kB, lazy chunk unchanged, CSS bundle minor +).
+- **Security gates** (to be verified pre-push): `pnpm audit` clean, no new deps, hardened secret-scan clean, no XSS sinks (zero dangerouslySetInnerHTML/eval/inline event-handler strings), Supabase auth flow `auth.getSession` + `auth.signOut` + `auth.onAuthStateChange` UNCHANGED — same call sites, same arguments, same handlers — only the visual frame around them differs. `vercel.json` not touched. `.env` not touched.
+- **Smoke-test scope** (wider than Phase 3a — Header is everywhere):
+  - `/` (landing) — public header (no profile, no logout, no rightLabel) renders correctly
+  - `/login` — auth header renders
+  - `/register` — auth header renders
+  - `/dashboard` — authenticated header renders, profile avatar visible, logout button visible, all auth-state transitions still work
+  - `/profile` — authenticated header renders, "My Profile" link target context (already on the profile page — link should behave correctly)
+  - LogFoodModal trigger from `/dashboard` — modal opens, header still visible behind backdrop
+  - Mobile viewport (390 px) — header doesn't overflow, "Sign out" text hides, hamburger-style works
+- **Deltas vs. plan:**
+  - **Avatar bumped 32 → 36 px.** Spec didn't explicitly call for this; rationale: visual symmetry with the wordmark icon (also 36 px) and consistency with the Primitives.jsx `AppHeader` round-button affordance size on the right. Doesn't change the touch-target floor. Document so we don't churn it back.
+- **Pending:** user visual + functional QA on the design/03b-header preview URL across all 5 routes, then merge into `feature/design-system` (PR coming next), then cut `design/03c-celebration` for Phase 3c.


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Production at `healtho-kohl.vercel.app` stays untouched. Ships on top of Phase 3.5 merge `53539f9`.

## File changed

- `apps/web/src/components/Header.jsx` — token-driven height + gutter, MaterialIcon primitive swaps, SKILL.md web-nav hover-underline, avatar size bump.

## Visual changes

| What | Before | After | Why |
|---|---|---|---|
| Height | `py-4` (~56 px) | `min-height: var(--nav-height)` → 72 px web / 56 px mobile | Matches SKILL.md "web top bar 72 px" rule and tokenizes the value |
| Horizontal padding | `px-6 lg:px-10` | `px-[var(--page-gutter)]` → `clamp(1rem, 4vw, 3rem)` | Token-driven, fluid across breakpoints |
| Wordmark | `font-bold tracking-tight` | `font-extrabold tracking-[-0.015em]` | Matches Primitives.jsx `AppHeader` spec |
| Right-link hover | `hover:underline` | `hover:underline underline-offset-4 decoration-primary/60` + focus-visible ring | SKILL.md web-nav rule + accessibility |
| Avatar size | 32 px (`w-8 h-8`) | 36 px (`w-9 h-9`) | Visual symmetry with the wordmark icon (also 36 px) and Primitives.jsx round-button affordance size |
| Icons | 3× raw `<span class=\"material-symbols-outlined\">` | `MaterialIcon` primitive | Single XSS-safe icon source |

## Behavioral preservation (verified line-by-line)

- All 4 props (`rightLabel`, `rightTo`, `rightIcon`, `showLogout`) unchanged
- `useEffect` auth-state setup (`getSession` then `onAuthStateChange` subscription, unsubscribe on unmount) — verbatim
- `handleLogout` flow (`setSigningOut` → `supabase.auth.signOut()` → `navigate('/login', { replace: true })`) — verbatim
- Logo route logic (`/dashboard` if session else `/login`) — verbatim
- Avatar fallback (`avatar_url` image if present, else two-letter initials from `full_name`) — verbatim
- Mobile-hidden \"Sign out\" text via `hidden sm:inline` — preserved

**Header is the spine of every authenticated page. Zero behavioral changes by design.**

## Visual + functional QA — wider than Phase 3a (Header is everywhere)

🔗 **Preview:** [healtho-git-design-03b-header-ayushkapoor11s-projects.vercel.app](https://healtho-git-design-03b-header-ayushkapoor11s-projects.vercel.app/) (URL active once Vercel finishes; short branch name avoids the Phase 3a alias-hashing issue)

### Routes to verify (5 minimum)
- [ ] **`/`** (landing) — public header renders, no profile, no logout, no rightLabel. 72 px tall on desktop. Wordmark + logo on left. Logo links to `/login` (no session) or `/dashboard` (session).
- [ ] **`/login`** — auth header renders (rightLabel="Register" or similar if set by Login page). Logo route logic still works.
- [ ] **`/register`** — auth header renders. Same wordmark + right-link pattern.
- [ ] **`/dashboard`** — authenticated header: wordmark on left, profile avatar (36 px circle, image or initials), \"Sign out\" button on the right with logout icon. **Click profile avatar** → navigates to `/profile`. **Click \"Sign out\"** → confirms logout, redirects to `/login`.
- [ ] **`/profile`** — authenticated header. **Click logo** → navigates to `/dashboard` (session active). **Click \"Sign out\"** → logs out.
- [ ] **LogFoodModal** triggered from dashboard — modal opens; header still visible behind the backdrop blur.
- [ ] **Mobile viewport (390 px)** — header doesn't overflow, \"Sign out\" text auto-hides (icon-only on `<sm`), avatar still 36 px.

### Hover / focus checks
- [ ] Right-link hover → underline with offset 4 px, decoration in `primary/60`
- [ ] Tab through header → focus ring on rightLabel link, profile avatar Link, and Sign out button (uses brand `--tap-ring` token)

### Auth-state regression checks
- [ ] Sign in → header instantly swaps logo target to `/dashboard` and shows avatar (subscription fires)
- [ ] Sign out → header instantly swaps logo target to `/login` and hides avatar (subscription fires)
- [ ] Page refresh while authenticated — `getSession` hydrates correctly, header renders authenticated state

## Security gates

| Gate | Status | Notes |
|---|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS | No known vulnerabilities |
| Zero new npm deps | ✅ PASS | Lockfile unchanged |
| No XSS sinks | ✅ PASS | Zero dangerouslySetInnerHTML / eval / inline event-handler strings; MaterialIcon passes name as JSX text child |
| Hardened secret-scan | ✅ PASS | Phase 3a's hardened pattern; clean despite touching the Supabase auth-listener code |
| Same-origin assets | ✅ PASS | No new external origins (Material Symbols still on Google CDN per the deferred Phase 1 deviation) |
| `vercel.json` untouched | ✅ PASS | — |
| Supabase auth flow untouched | ✅ PASS | `getSession`, `onAuthStateChange`, `signOut` call sites verbatim |
| `.env` untouched | ✅ PASS | — |

## Deltas vs. plan

- **Avatar bumped 32 → 36 px.** Spec didn't explicitly require this; doing it for visual symmetry with the 36 px wordmark icon and to match the Primitives.jsx `AppHeader` round-button affordance size on the right. No touch-target regression (still well above the 32 px web floor). Documented in the execution log.
- **`IconButton` / `Badge` / `Card` deliberately not used.** The rightLabel link is icon+text (doesn't fit IconButton), the logout is icon+text (same), the avatar is a `<Link>` wrapping an image-or-initials child (doesn't fit MealAvatar's emoji-or-children shape since we already have surface + border styling on the link itself), and the header surface is a `<header>` not a card. Forcing primitives in would create worse fits than explicit markup. Logged.

## Known QA noise (NOT a regression)

`vercel.live/_next-live/feedback/feedback.js` CSP block on previews — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)