### PR TITLE
Phase 3c: CelebrationOverlay reskin + reward keyframe wiring

### DIFF
--- a/apps/web/src/components/CelebrationOverlay.jsx
+++ b/apps/web/src/components/CelebrationOverlay.jsx
@@ -1,5 +1,27 @@
 import { useEffect, useRef } from 'react'
 import confetti from 'canvas-confetti'
+import { MaterialIcon } from '@healtho/ui'
+
+// CelebrationOverlay — full-screen goal-met celebration moment.
+//
+// Visual spec: project/ui_kits/app/ProfileCelebration.jsx (CelebrationScreen)
+// + project/preview/comp-celebration.html. Dual-ring glow on the badge,
+// decorative confetti around the card, custom 20px card radius, soft
+// shadow with violet/cyan glow per variant.
+//
+// Reward animations wired from @healtho/ui tokens.css (Phase 1):
+//   - rewardPop      — runs on the badge for the entry pop
+//   - rewardBurst    — runs on a decorative radial gradient behind the
+//                      badge for the "explosion" feel
+//   - rewardShimmer  — sweeps a highlight across the title text
+//
+// All three durations use var(--dur-reward) so prefers-reduced-motion
+// (which sets --dur-reward to 0ms in tokens.css) automatically collapses
+// the animations to their final state without extra plumbing.
+//
+// Behavior preservation: same props (visible, variant, onDismiss), same
+// canvas-confetti library calls, same audio chime, same 5s auto-dismiss,
+// same click-anywhere-to-dismiss.
 
 const BRAND_COLORS = ['#8b5cf6', '#e879f9', '#22d3ee', '#60b8d4']
 const AUTO_DISMISS_MS = 5000
@@ -9,7 +31,12 @@ const VARIANTS = {
     icon: 'water_drop',
     iconColor: 'text-water',
     badgeBg: 'bg-water/20',
-    ringColor: 'ring-water/30',
+    badgeShadow:
+      '0 0 0 5px rgba(96,184,212,0.25), 0 0 30px rgba(96,184,212,0.4)',
+    burstGradient:
+      'radial-gradient(circle, rgba(96,184,212,0.45) 0%, transparent 60%)',
+    cardGlow:
+      '0 25px 50px -12px rgba(0,0,0,0.7), 0 0 80px rgba(96,184,212,0.25)',
     title: 'Hydration Goal Complete!',
     subtitle: 'You hit 2.5L today. Great work staying hydrated.',
   },
@@ -17,11 +44,34 @@ const VARIANTS = {
     icon: 'emoji_events',
     iconColor: 'text-primary',
     badgeBg: 'bg-primary/20',
-    ringColor: 'ring-primary/30',
+    badgeShadow:
+      '0 0 0 5px rgba(139,92,246,0.25), 0 0 30px rgba(139,92,246,0.4)',
+    burstGradient:
+      'radial-gradient(circle, rgba(139,92,246,0.45) 0%, transparent 60%)',
+    cardGlow:
+      '0 25px 50px -12px rgba(0,0,0,0.7), 0 0 80px rgba(139,92,246,0.25)',
     title: 'Daily Goal Met!',
     subtitle: 'All meals logged and under your calorie target. Nice work!',
   },
 }
+
+// Static decorative confetti placed around the card per ProfileCelebration
+// spec. Pure visual — the canvas-confetti library handles the motion bursts.
+// Brand palette only (no rainbow, per SKILL.md non-negotiable).
+const STATIC_CONFETTI = [
+  { x:  8, y: 15, c: '#e879f9', r:  15, w: 6,  h: 6  },
+  { x: 88, y: 22, c: '#22d3ee', r: -10, w: 8,  h: 8  },
+  { x: 14, y: 46, c: '#8b5cf6', r:  45, w: 6,  h: 6  },
+  { x: 82, y: 18, c: '#60b8d4', r: -30, w: 10, h: 4  },
+  { x: 78, y: 52, c: '#e879f9', r:  60, w: 4,  h: 10 },
+  { x: 12, y: 64, c: '#22d3ee', r: -45, w: 5,  h: 12 },
+  { x: 40, y: 10, c: '#8b5cf6', r:  25, w: 7,  h: 3  },
+  { x: 65, y: 72, c: '#e879f9', r: -15, w: 6,  h: 6  },
+  { x: 25, y: 80, c: '#60b8d4', r:  50, w: 4,  h: 9  },
+  { x: 90, y: 78, c: '#8b5cf6', r: -55, w: 5,  h: 5  },
+  { x: 52, y: 86, c: '#22d3ee', r:  30, w: 6,  h: 3  },
+  { x: 48, y: 28, c: '#e879f9', r: -40, w: 4,  h: 7  },
+]
 
 export default function CelebrationOverlay({ visible, variant = 'water', onDismiss }) {
   const timerRef = useRef(null)
@@ -35,7 +85,7 @@ export default function CelebrationOverlay({ visible, variant = 'water', onDismi
     if (hasPlayed.current) return
     hasPlayed.current = true
 
-    // Confetti burst 1
+    // Confetti burst 1 — center
     confetti({
       particleCount: 120,
       spread: 80,
@@ -44,7 +94,7 @@ export default function CelebrationOverlay({ visible, variant = 'water', onDismi
       disableForReducedMotion: true,
     })
 
-    // Confetti burst 2 (layered, delayed)
+    // Confetti burst 2 — layered, delayed, off-center
     setTimeout(() => {
       confetti({
         particleCount: 60,
@@ -62,7 +112,7 @@ export default function CelebrationOverlay({ visible, variant = 'water', onDismi
       chime.play().catch(() => {})
     } catch { /* audio unavailable */ }
 
-    // Auto-dismiss
+    // Auto-dismiss after 5s
     timerRef.current = setTimeout(() => onDismiss?.(), AUTO_DISMISS_MS)
 
     return () => { if (timerRef.current) clearTimeout(timerRef.current) }
@@ -74,28 +124,98 @@ export default function CelebrationOverlay({ visible, variant = 'water', onDismi
 
   return (
     <div
-      className="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm flex items-center justify-center px-4"
+      className="fixed inset-0 z-[100] bg-black/60 backdrop-blur-sm flex items-center justify-center px-4 overflow-hidden"
       onClick={onDismiss}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="celebration-title"
     >
+      {/* Static decorative confetti — brand palette only, with subtle glow */}
+      {STATIC_CONFETTI.map((p, i) => (
+        <div
+          key={i}
+          aria-hidden="true"
+          className="absolute pointer-events-none rounded-sm"
+          style={{
+            left: `${p.x}%`,
+            top: `${p.y}%`,
+            width: p.w,
+            height: p.h,
+            background: p.c,
+            transform: `rotate(${p.r}deg)`,
+            boxShadow: `0 0 8px ${p.c}80`,
+          }}
+        />
+      ))}
+
+      {/* Card — celebration-enter handles the fade+scale entry from tokens.css */}
       <div
-        className="celebration-enter max-w-sm w-full rounded-2xl border border-slate-700/50 bg-surface p-8 text-center shadow-2xl"
+        className="celebration-enter relative max-w-sm w-full bg-surface border border-slate-700/50 px-7 pt-7 pb-6 text-center"
+        style={{
+          borderRadius: 20,
+          boxShadow: v.cardGlow,
+        }}
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Badge icon */}
-        <div className={`mx-auto w-20 h-20 rounded-full ${v.badgeBg} ring-4 ${v.ringColor} flex items-center justify-center mb-5`}>
-          <span className={`material-symbols-outlined text-4xl ${v.iconColor}`}>{v.icon}</span>
+        {/* Decorative burst behind badge — runs rewardBurst once */}
+        <div className="absolute inset-0 flex items-start justify-center pt-4 pointer-events-none" aria-hidden="true">
+          <div
+            className="w-32 h-32 rounded-full"
+            style={{
+              background: v.burstGradient,
+              animation: 'rewardBurst var(--dur-reward) cubic-bezier(0.16, 1, 0.3, 1) 100ms 1 both',
+            }}
+          />
         </div>
 
-        {/* Title */}
-        <h2 className="text-white text-2xl font-extrabold tracking-tight">{v.title}</h2>
+        {/* Badge — dual-ring glow + rewardPop entry */}
+        <div className="relative mx-auto mb-4 flex items-center justify-center" style={{ width: 80, height: 80 }}>
+          <div
+            className={`w-20 h-20 rounded-full ${v.badgeBg} flex items-center justify-center`}
+            style={{
+              boxShadow: v.badgeShadow,
+              animation: 'rewardPop var(--dur-reward) var(--ease-spring) both',
+            }}
+          >
+            <MaterialIcon
+              name={v.icon}
+              size={40}
+              fill={1}
+              className={v.iconColor}
+            />
+          </div>
+        </div>
+
+        {/* Title — rewardShimmer sweeps a brighter highlight across once */}
+        <h2
+          id="celebration-title"
+          className="relative font-extrabold tracking-[-0.015em] font-display"
+          style={{
+            fontSize: 26,
+            backgroundImage:
+              'linear-gradient(90deg, #ffffff 0%, #ffffff 38%, #c4b5fd 50%, #ffffff 62%, #ffffff 100%)',
+            backgroundSize: '220% 100%',
+            backgroundPosition: '50% 50%',
+            backgroundClip: 'text',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            color: 'transparent',
+            animation: 'rewardShimmer var(--dur-reward) ease-out 400ms 1 both',
+          }}
+        >
+          {v.title}
+        </h2>
 
         {/* Subtitle */}
-        <p className="text-slate-400 text-sm mt-2 leading-relaxed">{v.subtitle}</p>
+        <p className="relative mt-2 text-sm text-slate-300 font-display" style={{ lineHeight: 1.55 }}>
+          {v.subtitle}
+        </p>
 
         {/* Dismiss hint */}
         <button
+          type="button"
           onClick={onDismiss}
-          className="mt-6 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          className="relative mt-6 text-xs text-slate-500 hover:text-slate-300 transition-colors font-display focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)] rounded px-2 py-1"
         >
           Tap anywhere to dismiss
         </button>

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -621,4 +621,51 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
   - Mobile viewport (390 px) — header doesn't overflow, "Sign out" text hides, hamburger-style works
 - **Deltas vs. plan:**
   - **Avatar bumped 32 → 36 px.** Spec didn't explicitly call for this; rationale: visual symmetry with the wordmark icon (also 36 px) and consistency with the Primitives.jsx `AppHeader` round-button affordance size on the right. Doesn't change the touch-target floor. Document so we don't churn it back.
-- **Pending:** user visual + functional QA on the design/03b-header preview URL across all 5 routes, then merge into `feature/design-system` (PR coming next), then cut `design/03c-celebration` for Phase 3c.
+- **Visual + functional QA:** PASS. User reviewed all routes across the design/03b-header preview, approved as-is.
+- **PR:** [#11](https://github.com/healtho-app/healtho/pull/11), merged 2026-04-30 via `gh pr merge --merge`.
+- **Merge SHA into feature branch:** `cdbde278610d5091c0e3c091a4df98f2d9027248`.
+- **Sub-branch closed at:** `819da89`.
+- **Vercel alias confirmation:** `healtho-git-design-03b-header-...vercel.app` resolved cleanly without hashing — naming heuristic confirmed for all remaining sub-branches.
+
+### Phase 3c — CelebrationOverlay reskin (wires reward keyframes)
+
+- **Date:** 2026-04-30
+- **Sub-branch:** `design/03c-celebration` cut from `feature/design-system@cdbde27`.
+- **Phase 3c commit:** `feat(app): Phase 3c — CelebrationOverlay reskin` (SHA appended below post-push).
+- **File modified:** `apps/web/src/components/CelebrationOverlay.jsx`.
+- **Visual changes (per `project/ui_kits/app/ProfileCelebration.jsx` `CelebrationScreen` + `comp-celebration.html`):**
+  - **Card:** `bg-surface` (`#0e0b1e`) with `border-slate-700/50`, `border-radius: 20px` (between Card primitive's xl=12 and 2xl=16; explicit inline `borderRadius: 20`), custom `boxShadow: 0 25px 50px -12px rgba(0,0,0,0.7), 0 0 80px rgba(<variant>,0.25)` per-variant glow.
+  - **Badge:** 80×80 round, `bg-{variant}/20` + dual-ring shadow `0 0 0 5px rgba(<variant>,0.25), 0 0 30px rgba(<variant>,0.4)` (replaces the prior single `ring-4` Tailwind utility).
+  - **Decorative burst behind badge:** new 128×128 round element with radial-gradient (`rgba(<variant>,0.45) 0%, transparent 60%`), runs `rewardBurst` keyframe once on mount (Phase 1 token wiring goal).
+  - **Title:** 26 px font-extrabold `tracking-[-0.015em]` (was 24 px `tracking-tight`), with a brighter-white-to-violet-to-white gradient swept via `rewardShimmer` keyframe + `background-clip: text` once on mount. Sits over a transparent fill so the gradient shows through the glyphs.
+  - **Subtitle:** `text-slate-300` (was `text-slate-400`) at 14 px line-height 1.55.
+  - **Static decorative confetti:** 12 fixed-position rectangles (per ProfileCelebration spec), brand palette only, each with `box-shadow: 0 0 8px ${color}80` glow, `transform: rotate(...)`. Layered around the card during entry, in addition to the existing canvas-confetti dynamic bursts.
+  - **3 raw `<span class="material-symbols-outlined">`** (only one in the original) → `MaterialIcon` primitive with `fill={1}` (filled icon).
+- **Reward animations wired (Phase 3c's main brief goal):**
+  - `rewardPop` on the badge — entry pop, scale 0.6 → 1.12 → 0.96 → 1, duration `var(--dur-reward)`, easing `var(--ease-spring)`.
+  - `rewardBurst` on the decorative gradient circle — 0.1s delay, runs once, `cubic-bezier(0.16, 1, 0.3, 1)`.
+  - `rewardShimmer` on the title text — 0.4s delay (after badge pop), runs once, `ease-out`.
+  - All three durations reference `var(--dur-reward)` so `prefers-reduced-motion` (which sets `--dur-reward: 0ms` in `tokens.css`) collapses them automatically. SKILL.md non-negotiable §15 honored without extra plumbing.
+- **Behavior preservation (verified line-by-line):**
+  - Props (`visible`, `variant`, `onDismiss`) — unchanged.
+  - VARIANTS map — same 'water' and 'meals' keys, same icon/title/subtitle copy. Added per-variant fields for badgeShadow, burstGradient, cardGlow.
+  - canvas-confetti library calls — verbatim. Same particle counts (120 + 60), same spread (80, 100), same origins, same `disableForReducedMotion: true`, same `BRAND_COLORS` palette.
+  - Audio chime — verbatim try/catch around `new Audio('/sounds/celebration.wav')`, volume 0.5, silent failure.
+  - Auto-dismiss — same 5000 ms timer with cleanup.
+  - Click-anywhere-to-dismiss — preserved (root onClick + inner stopPropagation).
+  - "Tap anywhere to dismiss" hint button — preserved with new focus ring via `--tap-ring`.
+  - `hasPlayed` ref guard preventing duplicate confetti / chime on re-renders — preserved.
+- **Primitives consumed:** `MaterialIcon` (1 usage with `fill={1}` + `size={40}` + className for color). `Modal` deliberately NOT used — its `bg-slate-900` / `rounded-2xl` / `--shadow-2xl` defaults don't match the celebration's `bg-surface` / 20-px-radius / per-variant glow shadow, and overriding via `className` is fragile without `tailwind-merge`. `Card` deliberately NOT used — needs 20-px radius which the Phase 3.5 prop set doesn't expose (closest is xl=12 or 2xl=16).
+- **Build:** `pnpm build` green in 3.7 s.
+- **Security gates:** `pnpm audit` clean, zero new deps, hardened secret-scan to be verified pre-push, no XSS sinks (zero `dangerouslySetInnerHTML` / `eval` / inline event-handler strings), `vercel.json` not touched, Supabase / `.env` not touched. canvas-confetti library was already present (pre-Phase-3 dep).
+- **Smoke-test scope:**
+  - **Trigger the celebration on `/dashboard`** (hit calorie goal in test data OR fill 8 water glasses) — confirm the overlay appears, badge pops in, decorative burst fades behind, title shimmers, confetti library bursts fire.
+  - **Variant `water`** (8 glasses filled) — cyan dual-ring + cyan glow + water_drop icon + "Hydration Goal Complete!" title.
+  - **Variant `meals`** (calorie goal hit) — violet dual-ring + violet glow + emoji_events icon + "Daily Goal Met!" title.
+  - **Click anywhere** dismisses; auto-dismiss fires after 5 s if untouched.
+  - **`prefers-reduced-motion: reduce`** — overlay still appears with all elements in their final state, but the rewardPop/rewardBurst/rewardShimmer animations don't play (durations collapse to 0). Verify in macOS System Preferences → Accessibility → Display → Reduce Motion, or DevTools → Rendering → "Emulate CSS prefers-reduced-motion".
+  - **Audio chime** — fires once per celebration (or silently fails if browser blocks autoplay).
+- **Deltas vs. plan:**
+  - **Card primitive not used for the celebration card.** Spec wants 20 px radius which the Phase 3.5 `radius` prop doesn't expose (the prop has none/lg/xl/2xl mapping to standard Tailwind values 0/8/12/16; 20 is non-standard). Keeping raw `<div>` with explicit `borderRadius: 20`. **Pickup candidate**: Card primitive could expose a `radius="3xl"` (24 px) or accept arbitrary numeric values, but that's primitive-design churn for one consumer; flagging for awareness, not requesting.
+  - **Modal primitive not used for the overlay.** Modal's hardcoded `bg-slate-900 / rounded-2xl / shadow-[var(--shadow-2xl)]` doesn't fit the celebration's `bg-surface / 20-px / per-variant glow`. Overriding via `className` is unreliable without `tailwind-merge`. Keeping the explicit overlay logic — it's only ~20 lines of JSX and matches the spec exactly.
+- **Pending:** user visual + functional QA on the design/03c-celebration preview URL — specifically trigger BOTH variants (water + meals), verify all three reward keyframes fire, then merge into `feature/design-system`. After 3c lands, the 3-series is complete and Phase 4 (page-level reskins: Dashboard, Auth, Profile, LogFoodModal) can begin.


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Closes the 3-series. Ships on top of Phase 3b merge `cdbde27`.

## What ships

`apps/web/src/components/CelebrationOverlay.jsx` — visual uplift per `project/ui_kits/app/ProfileCelebration.jsx` `CelebrationScreen` + wiring of the three Phase 1 reward keyframes from `@healtho/ui` tokens.css.

## Reward keyframes — the headline change

| Keyframe | Where | Trigger | Duration |
|---|---|---|---|
| `rewardPop` | Badge (the 80×80 round icon) | On entry, 0 ms delay | `var(--dur-reward)` × `var(--ease-spring)` |
| `rewardBurst` | New decorative radial-gradient circle behind the badge | 100 ms delay | `var(--dur-reward)` × `cubic-bezier(0.16,1,0.3,1)` |
| `rewardShimmer` | Title text (gradient swept via `background-clip: text`) | 400 ms delay (after badge pop) | `var(--dur-reward)` × `ease-out` |

All three durations reference `var(--dur-reward)`, so `prefers-reduced-motion` collapses them to 0 ms automatically (per `tokens.css` media query). SKILL.md §15 honored without extra plumbing.

## Visual changes (per spec)

| Element | Before | After |
|---|---|---|
| Card radius | `rounded-2xl` (16 px) | 20 px (per ProfileCelebration spec) |
| Card surface | `bg-surface` (was already correct) | unchanged |
| Card border | `border-slate-700/50` | unchanged |
| Card shadow | `shadow-2xl` | per-variant `0 25px 50px -12px rgba(0,0,0,0.7), 0 0 80px rgba(<variant>,0.25)` |
| Badge glow | `ring-4 ring-{variant}/30` (single ring) | dual-ring `0 0 0 5px rgba(<variant>,0.25), 0 0 30px rgba(<variant>,0.4)` |
| Badge entry | `celebration-enter` (whole card) | `rewardPop` keyframe on the badge specifically |
| Behind badge | nothing | `rewardBurst` decorative gradient circle |
| Title size | 24 px (`text-2xl`) | 26 px |
| Title shimmer | none | `rewardShimmer` swept gradient on entry |
| Subtitle color | `text-slate-400` | `text-slate-300` (matches spec body color) |
| Decorative confetti | none (only canvas-confetti library bursts) | 12 fixed-position rectangles around the card with per-color glow, brand palette only |
| Icons | `<span class=\"material-symbols-outlined\">` | `MaterialIcon` primitive with `fill={1}` |
| Per-variant theming | icon + bg + ringColor + title + subtitle | adds `badgeShadow`, `burstGradient`, `cardGlow` strings per variant |

## Behavioral preservation (verified line-by-line)

- All 3 props (`visible`, `variant`, `onDismiss`) — unchanged
- VARIANTS map — same `'water'` / `'meals'` keys, same icon names, same titles, same subtitles
- canvas-confetti library calls — verbatim (particle counts 120 + 60, spreads 80 + 100, origins, `disableForReducedMotion: true`, `BRAND_COLORS` palette)
- Audio chime — verbatim try/catch around `new Audio('/sounds/celebration.wav')`, volume 0.5
- Auto-dismiss after 5 s — preserved with cleanup
- Click-anywhere-to-dismiss — preserved (root onClick + inner stopPropagation)
- `hasPlayed` ref guard — preserved
- \"Tap anywhere to dismiss\" hint button — preserved with new `--tap-ring` focus ring

## Visual + functional QA

🔗 **Preview:** [healtho-git-design-03c-celebration-ayushkapoor11s-projects.vercel.app](https://healtho-git-design-03c-celebration-ayushkapoor11s-projects.vercel.app/) (URL active once Vercel finishes; short branch name avoids alias hashing)

### Trigger checklist
- [ ] **`/dashboard` — water variant** (fill all 8 water glasses) — overlay appears with cyan dual-ring badge, water_drop filled icon, \"Hydration Goal Complete!\" title with shimmer sweep, cyan card glow
- [ ] **`/dashboard` — meals variant** (push consumed ≥ goal in test data) — overlay appears with violet dual-ring badge, emoji_events filled icon, \"Daily Goal Met!\" title with shimmer sweep, violet card glow
- [ ] **All three reward keyframes fire on entry**: badge pops in (rewardPop), decorative circle bursts behind it (rewardBurst), title shimmers across (rewardShimmer)
- [ ] **canvas-confetti library bursts** still fire (120 particles + 60 layered) — visible motion in addition to the static decorative confetti
- [ ] **Static decorative confetti** — 12 colored rectangles visible around the card, with subtle color glow
- [ ] **Audio chime** — fires once per celebration (or silently fails if browser blocks autoplay)
- [ ] **Click anywhere** dismisses; **5 s auto-dismiss** if untouched
- [ ] **\"Tap anywhere to dismiss\" hint** — clickable, has focus ring on tab

### prefers-reduced-motion check
- [ ] DevTools → Rendering → \"Emulate CSS prefers-reduced-motion: reduce\" → trigger celebration → overlay still appears with all elements in their final state, but the rewardPop/rewardBurst/rewardShimmer animations don't visibly play (durations collapse to 0 ms via `--dur-reward` token). canvas-confetti library also disables motion via `disableForReducedMotion: true`.

## Security gates

| Gate | Status |
|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS |
| Zero new npm deps | ✅ PASS — canvas-confetti was already a dep |
| No XSS sinks | ✅ PASS |
| Hardened secret-scan | ✅ PASS |
| Same-origin assets | ✅ PASS — `/sounds/celebration.wav` already present in `apps/web/public` |
| `vercel.json` untouched | ✅ PASS |
| Supabase / `.env` untouched | ✅ PASS — celebration is presentation-only |

## Deltas vs. plan

1. **Card primitive not used for the celebration card.** Spec wants 20 px radius which the Phase 3.5 `radius` prop (none / lg=8 / xl=12 / 2xl=16) doesn't expose. Keeping raw `<div>` with explicit inline `borderRadius: 20`. **Pickup candidate**: Card could expose a `radius=\"3xl\"` (24 px) or accept arbitrary numeric values — flagging for awareness, not requesting in this PR.
2. **Modal primitive not used for the overlay.** Modal's hardcoded `bg-slate-900 / rounded-2xl / shadow-[var(--shadow-2xl)]` doesn't fit the celebration's `bg-surface / 20-px / per-variant glow`. Overriding via `className` is unreliable without `tailwind-merge`. Keeping the explicit overlay logic — only ~25 lines of JSX and matches the spec exactly.

## Known QA noise (NOT a regression)

`vercel.live/_next-live/feedback/feedback.js` CSP block on previews — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)