### PR TITLE
Phase 4a: Dashboard page reskin

### DIFF
--- a/apps/web/src/pages/Dashboard.jsx
+++ b/apps/web/src/pages/Dashboard.jsx
@@ -1,12 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
-// Drinks that count toward water tracker, mapped to ml per serving
-const WATER_SERVING_ML = {
-  'Water':           250,
-  'Sparkling Water': 355,
-  'Coconut Water':   240,
-  'Nimbu Pani':      250,
-}
+import { Button, Card, IconButton, MaterialIcon } from '@healtho/ui'
 import { useProfile }  from '../contexts/ProfileContext'
 import Header            from '../components/Header'
 import CalorieRing       from '../components/CalorieRing'
@@ -19,11 +13,22 @@ import CelebrationOverlay from '../components/CelebrationOverlay'
 import { useCelebration } from '../hooks/useCelebration'
 import { computeMacroTargets } from '../lib/macroTargets'
 
+// Drinks that count toward water tracker, mapped to ml per serving
+const WATER_SERVING_ML = {
+  'Water':           250,
+  'Sparkling Water': 355,
+  'Coconut Water':   240,
+  'Nimbu Pani':      250,
+}
+
+// Meal-type emojis match the design-system rubric (SKILL.md non-negotiable
+// §8: emoji only in two contexts, meal types and activity-level pickers).
+// Updated from sun/moon/sunrise emojis to the rubric's egg/salad/plate/apple.
 const MEAL_META = [
-  { id: 'breakfast', emoji: '🌅', name: 'Breakfast', defaultOpen: true  },
-  { id: 'lunch',     emoji: '☀️', name: 'Lunch',     defaultOpen: false },
-  { id: 'dinner',    emoji: '🌙', name: 'Dinner',    defaultOpen: false },
-  { id: 'snacks',    emoji: '🍎', name: 'Snacks',    defaultOpen: false },
+  { id: 'breakfast', emoji: '🍳',  name: 'Breakfast', defaultOpen: true  },
+  { id: 'lunch',     emoji: '🥗',  name: 'Lunch',     defaultOpen: false },
+  { id: 'dinner',    emoji: '🍽️', name: 'Dinner',    defaultOpen: false },
+  { id: 'snacks',    emoji: '🍎',  name: 'Snacks',    defaultOpen: false },
 ]
 
 const ACTIVITY_MULTIPLIERS = {
@@ -273,6 +278,10 @@ export default function Dashboard() {
   const firstName = profile?.full_name?.split(' ')[0] || 'there'
   const username  = profile?.username ? `@${profile.username}` : null
 
+  // Streak title text — kept dynamic for behavioral preservation. The
+  // visual treatment moves to DM Mono per the design-system spec.
+  const streakTitle = streak === 0 ? 'No streak yet' : `${streak} day streak`
+
   // ── Blocking error fallback ────────────────────────────────────────────────
   // For auth/notfound errors there's no meaningful dashboard to render — the
   // user must re-auth or finish onboarding. Short-circuit with a fullpage card
@@ -317,52 +326,59 @@ export default function Dashboard() {
             />
           )}
 
-          {/* Greeting */}
+          {/* Greeting + date navigator */}
           <div className="mb-2">
-            {/* Date navigator */}
-            <div className="flex items-center gap-2 mb-1">
-              <button
+            {/* Date navigator row */}
+            <div className="flex items-center gap-2 mb-2">
+              <IconButton
+                icon="chevron_left"
+                size="sm"
+                variant="plain"
                 onClick={goBack}
                 disabled={isAtEarliest}
-                className={`w-7 h-7 rounded-full flex items-center justify-center transition-colors flex-shrink-0 ${isAtEarliest ? 'text-slate-700 cursor-not-allowed' : 'bg-slate-800 hover:bg-slate-700 text-white'}`}
                 aria-label="Previous day"
                 title={isAtEarliest ? `History limited to ${MAX_HISTORY_DAYS} days` : 'Previous day'}
-              >
-                <span className="material-symbols-outlined text-sm">chevron_left</span>
-              </button>
-              <p className="text-slate-400 text-sm font-medium flex-1 truncate">{dateLabel}</p>
+              />
+              <p className="eyebrow flex-1 truncate normal-case tracking-wider text-slate-400 font-medium">
+                {dateLabel}
+              </p>
               {/* "Today" quick-jump — only shown when not on today */}
               {!isToday && (
                 <button
+                  type="button"
                   onClick={() => setSelectedDate(localDateStr())}
-                  className="text-[10px] font-bold text-primary bg-primary/10 hover:bg-primary/20 px-2 py-1 rounded-lg transition-colors flex-shrink-0"
+                  className="inline-flex items-center rounded-full bg-primary/[0.15] text-violet-300 border border-primary/35 px-3 py-1 text-[11px] font-semibold font-display hover:bg-primary/[0.25] transition-colors focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)]"
                 >
                   Today
                 </button>
               )}
-              <button
-                onClick={goForward}
-                disabled={isToday}
-                className={`w-7 h-7 rounded-full flex items-center justify-center transition-colors flex-shrink-0 ${isToday ? 'text-slate-700 cursor-not-allowed opacity-0 pointer-events-none' : 'bg-slate-800 hover:bg-slate-700 text-white'}`}
-                aria-label="Next day"
-              >
-                <span className="material-symbols-outlined text-sm">chevron_right</span>
-              </button>
+              <div className={isToday ? 'opacity-0 pointer-events-none' : ''} aria-hidden={isToday}>
+                <IconButton
+                  icon="chevron_right"
+                  size="sm"
+                  variant="plain"
+                  onClick={goForward}
+                  disabled={isToday}
+                  aria-label="Next day"
+                />
+              </div>
             </div>
 
             {loading ? <Skeleton className="h-10 w-64 mt-1" /> : (
-              <h1 className="text-white text-4xl font-extrabold leading-tight tracking-tight mt-1">
-                {greeting(profile?.timezone)}, <span className="text-primary">{firstName}</span> 👋
+              <h1 className="text-3xl font-extrabold leading-tight tracking-[-0.02em] text-white font-display">
+                {greeting(profile?.timezone)},{' '}
+                <span className="text-gradient">{firstName}</span> 👋
               </h1>
             )}
-            <p className="text-slate-500 text-base mt-1">
-              {isToday ? "Here's your nutrition summary for today." : `Viewing logs for ${new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}.`}
-              {username && <span className="ml-2 text-slate-600 font-mono text-sm">{username}</span>}
+            <p className="mt-1 text-base text-slate-400 font-display">
+              {isToday
+                ? "Here's your nutrition summary for today."
+                : `Viewing logs for ${new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}.`}
+              {username && (
+                <span className="ml-2 text-slate-600 font-mono text-sm">{username}</span>
+              )}
             </p>
           </div>
-
-          {/* Calorie goal banner removed — CalorieRing already shows the same
-              daily_calorie_goal value. BMI + weight live on Profile page. */}
 
           {/* Calorie ring — live consumed from food_logs. Hidden during a
               partial profile error since the goal would be 0 and misleading. */}
@@ -376,31 +392,49 @@ export default function Dashboard() {
           </div>
 
           {/* Water */}
-          <WaterTracker waterLevel={waterLevel} goalMet={waterGoalMet} onLevelChange={setWaterTotalLevel} isToday={isToday} />
+          <WaterTracker
+            waterLevel={waterLevel}
+            goalMet={waterGoalMet}
+            onLevelChange={setWaterTotalLevel}
+            isToday={isToday}
+          />
 
           {/* Meals header */}
           <div className="flex items-center justify-between pt-2">
-            <p className="text-slate-400 text-xs font-bold uppercase tracking-wider">
-              {isToday ? "Today's Meals" : new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' })}
+            <p className="label text-slate-400">
+              {isToday
+                ? "Today's Meals"
+                : new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' })}
             </p>
-            <button onClick={() => { setLogMeal(null); setLogOpen(true) }} className="text-primary text-xs font-semibold hover:underline">
-              + Log food
+            <button
+              type="button"
+              onClick={() => { setLogMeal(null); setLogOpen(true) }}
+              className="inline-flex items-center gap-1 text-primary text-xs font-semibold font-display hover:underline underline-offset-4 decoration-primary/60 focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)] rounded px-1 py-0.5"
+            >
+              <MaterialIcon name="add" size={14} />
+              Log food
             </button>
           </div>
 
-          {/* Meal sections — real data */}
+          {/* Meal sections — real data. Empty state for past dates with no logs. */}
           {logs.length === 0 && !loading && !isToday ? (
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 text-center">
+            <Card padding="lg" radius="xl" className="text-center">
               <p className="text-3xl mb-2">📋</p>
-              <p className="text-slate-300 text-sm font-semibold">No entries for this day</p>
-              <p className="text-slate-600 text-xs mt-1">Nothing was logged on {new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}.</p>
+              <p className="text-sm font-semibold text-slate-300 font-display">
+                No entries for this day
+              </p>
+              <p className="text-xs text-slate-600 mt-1 font-display">
+                Nothing was logged on {new Date(selectedDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric' })}.
+              </p>
               <button
+                type="button"
                 onClick={() => { setLogMeal(null); setLogOpen(true) }}
-                className="mt-3 text-primary text-xs font-semibold hover:underline"
+                className="mt-3 inline-flex items-center gap-1 text-primary text-xs font-semibold font-display hover:underline underline-offset-4 decoration-primary/60 focus-visible:outline-none focus-visible:shadow-[var(--tap-ring)] rounded px-1 py-0.5"
               >
-                + Add an entry for this day
+                <MaterialIcon name="add" size={14} />
+                Add an entry for this day
               </button>
-            </div>
+            </Card>
           ) : (
             meals.map(meal => (
               <MealSection
@@ -417,18 +451,27 @@ export default function Dashboard() {
             ))
           )}
 
-          {/* Streak */}
+          {/* Streak — kept as raw <div> wrapper so the absolute-positioned
+              tooltip can escape its sibling card's bounds. Card primitive's
+              overflow-hidden would clip the tooltip. The inner card surface
+              uses the same slate-900/border-slate-800/rounded-xl shape as Card
+              for visual parity. */}
           <div className="relative group">
             <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 flex items-center gap-4 cursor-default">
-              <div className="w-10 h-10 rounded-xl bg-slate-800 flex items-center justify-center text-2xl flex-shrink-0">🔥</div>
-              <div className="flex-1">
-                <p className="text-sm font-bold text-white flex items-center gap-2">
-                  {streak === 0 ? 'No streak yet' : `Day ${streak} streak`}
+              {/* Brand-gradient flame circle (replaces the prior slate emoji box) */}
+              <div className="flex-shrink-0 w-11 h-11 rounded-full bg-brand-gradient flex items-center justify-center shadow-[0_8px_20px_-6px_rgba(139,92,246,0.5)]">
+                <MaterialIcon name="local_fire_department" size={22} fill={1} className="text-white" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-mono text-base font-bold text-white flex items-center gap-2 truncate">
+                  {streakTitle}
                   {!isToday && (
-                    <span className="text-[10px] font-semibold text-slate-500 bg-slate-800 px-2 py-0.5 rounded-full">current</span>
+                    <span className="font-display text-[10px] font-semibold text-slate-500 bg-slate-800 px-2 py-0.5 rounded-full whitespace-nowrap">
+                      current
+                    </span>
                   )}
                 </p>
-                <p className="text-xs font-semibold mt-0.5 text-green-400">
+                <p className="text-xs font-semibold mt-0.5 text-fiber font-display">
                   {streak === 0 && 'Log a meal today to start your streak!'}
                   {streak === 1 && "Great start — log tomorrow to keep it going!"}
                   {streak >= 2 && streak < 7  && `${streak} days in a row — keep it up!`}
@@ -436,52 +479,58 @@ export default function Dashboard() {
                   {streak >= 30 && `🏆 ${streak} days — absolute legend!`}
                 </p>
               </div>
-              <span className="material-symbols-outlined text-primary">emoji_events</span>
+              <MaterialIcon name="emoji_events" size={22} className="text-primary flex-shrink-0" />
             </div>
 
-            {/* Tooltip — z-50 so it renders above all meal cards */}
-            <div className="absolute bottom-full left-0 right-0 mb-2 z-50 pointer-events-none
-                            opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            {/* Tooltip — absolute, sibling of card, z-50 so it renders above all meal cards */}
+            <div
+              role="tooltip"
+              className="absolute bottom-full left-0 right-0 mb-2 z-50 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+            >
               <div className="bg-slate-800 border border-slate-700 rounded-xl p-4 shadow-xl">
-                <p className="text-xs font-bold text-white mb-2 flex items-center gap-1.5">
+                <p className="text-xs font-bold text-white mb-2 flex items-center gap-1.5 font-display">
                   <span className="text-base">🔥</span> How streaks work
                 </p>
                 <ul className="space-y-1.5">
-                  <li className="flex items-start gap-2 text-xs text-slate-400">
-                    <span className="text-green-400 mt-0.5">✓</span>
+                  <li className="flex items-start gap-2 text-xs text-slate-400 font-display">
+                    <span className="text-fiber mt-0.5">✓</span>
                     Log <span className="text-white font-semibold mx-1">at least 1 meal</span> per day to grow your streak
                   </li>
-                  <li className="flex items-start gap-2 text-xs text-slate-400">
-                    <span className="text-green-400 mt-0.5">✓</span>
+                  <li className="flex items-start gap-2 text-xs text-slate-400 font-display">
+                    <span className="text-fiber mt-0.5">✓</span>
                     Consecutive days logged = streak count
                   </li>
-                  <li className="flex items-start gap-2 text-xs text-slate-400">
+                  <li className="flex items-start gap-2 text-xs text-slate-400 font-display">
                     <span className="text-red-400 mt-0.5">✕</span>
                     Miss a day and your streak resets to 0
                   </li>
-                  <li className="flex items-start gap-2 text-xs text-slate-400">
+                  <li className="flex items-start gap-2 text-xs text-slate-400 font-display">
                     <span className="text-yellow-400 mt-0.5">◷</span>
                     You have until midnight to log and keep today's streak alive
                   </li>
                 </ul>
               </div>
-              {/* Arrow */}
               <div className="w-3 h-3 bg-slate-800 border-r border-b border-slate-700 rotate-45 mx-auto -mt-1.5" />
             </div>
           </div>
 
-          {/* Log Food CTA */}
-          <button onClick={() => { setLogMeal(null); setLogOpen(true) }}
-            className="w-full h-14 bg-primary hover:bg-primary-dark text-white rounded-xl font-bold text-lg shadow-lg shadow-primary/20 transition-all flex items-center justify-center gap-2 group">
-            <span className="material-symbols-outlined">add_circle</span>
+          {/* Log Food CTA — Phase 2 Button primary variant gives the brand
+              gradient + soft violet shadow per spec. */}
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={() => { setLogMeal(null); setLogOpen(true) }}
+            className="w-full"
+          >
+            <MaterialIcon name="add_circle" size={20} fill={1} />
             Log Food
-          </button>
+          </Button>
 
         </div>
       </main>
 
       <footer className="py-6 px-6 text-center">
-        <p className="text-slate-700 text-xs">© {new Date().getFullYear()} Healtho. All rights reserved.</p>
+        <p className="text-slate-700 text-xs font-display">© {new Date().getFullYear()} Healtho. All rights reserved.</p>
       </footer>
 
       <LogFoodModal

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -726,4 +726,64 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
 - **Surprises / things to flag:**
   - **`vercel.json` CSP entries for `fonts.googleapis.com` (style-src) and `fonts.gstatic.com` (font-src) are now dead permissions.** Tightening the CSP is a Phase 6 polish candidate (with user approval, since the hard rule restricts CSP changes).
   - **`ProtectedRoute.jsx` and `ProfileLoadError.jsx` not migrated to `MaterialIcon` primitive yet.** They render correctly with the self-hosted font (CSS class continues to work) but they bypass the primitive's XSS-safe text-content guarantee. Worth picking up during Phase 4c (Profile reskin) since `ProfileLoadError` lives near the Profile flow.
-- **Pending:** user visual QA on the design/03d-self-host-ms preview URL — specifically Network-tab evidence (zero `fonts.googleapis.com` / `fonts.gstatic.com` requests) + side-by-side icon-rendering parity vs the feature/design-system preview (which still serves CDN). Then merge.
+- **Visual + same-origin QA:** PASS. User confirmed via DevTools Network tab on the design/03d-self-host-ms preview that ZERO requests hit `fonts.googleapis.com` or `fonts.gstatic.com`. All four font assets — three Lexend cuts + the new `MaterialSymbolsOutlined-Variable-OqZILbjW.woff2` — load from the same Vercel origin (`/assets/`). The "same-origin assets only" hard rule is now fully honored.
+- **PR:** [#13](https://github.com/healtho-app/healtho/pull/13), merged 2026-05-01 via `gh pr merge --merge`.
+- **Merge SHA into feature branch:** `9c54d1f471bfb899dc891a966e6a6eed9db465eb`.
+- **Sub-branch closed at:** `9c8e4a4`.
+- **Pickup A is officially CLOSED.** All three brand-font families (Lexend, DM Mono, Material Symbols Outlined) self-hosted with no third-party CDN dependencies remaining in the React app.
+
+### Phase 4a — Dashboard page reskin
+
+- **Date:** 2026-05-01
+- **Sub-branch:** `design/04a-dashboard` cut from `feature/design-system@9c54d1f` (no overnight activity on main; sync gate #2 not needed).
+- **Phase 4a commit:** `feat(app): Phase 4a — Dashboard page reskin` (SHA appended below post-push).
+- **File modified:** `apps/web/src/pages/Dashboard.jsx` (508 lines pre-reskin).
+- **Why:** Highest-traffic screen. Page-level chrome + section composition + typography hierarchy now match `project/ui_kits/app/Dashboard.jsx` spec while leaving every state hook, callback, supabase query, and computed value verbatim. Visual reskin only — props in, same data out.
+- **Visual changes (page-level only — components themselves were reskinned in Phase 3):**
+  - **MEAL_META emojis updated** to match SKILL.md non-negotiable §8 (emoji only in meal-types and activity-pickers, with a fixed palette). Was `🌅 / ☀️ / 🌙 / 🍎`, now `🍳 / 🥗 / 🍽️ / 🍎` per the rubric. This is a constant local to the file; no API/data-shape impact.
+  - **Greeting block** retitled to match Primitives.jsx-derived spec: `text-3xl font-extrabold tracking-[-0.02em]` (was `text-4xl tracking-tight`); first name now wrapped in `text-gradient` semantic class (Phase 1 token); subtitle changed from `text-slate-500` to `text-slate-400` per spec body color.
+  - **Date navigator** chevrons swapped from raw buttons to `IconButton variant="plain" size="sm"` primitive consumers; "Today" quick-jump styled to match `Badge variant="pop"` shape (raw button retained because Badge isn't a clickable primitive — see deltas).
+  - **Meals header** "+ Log food" inline trigger uses `MaterialIcon` for the `add` icon plus the SKILL.md hover-underline pattern with `--tap-ring` focus ring (matches Header's right-link affordance).
+  - **Empty-state card** (no entries on past dates) now wraps in `Card padding="lg" radius="xl"` primitive consumer; replaces the prior raw `<div>` shell. Same visual, primitive consumption is consistent.
+  - **Streak card** is the biggest single change: brand-gradient flame circle replaces the slate emoji box. 44 px round, `bg-brand-gradient` fill, `MaterialIcon name="local_fire_department" fill={1}` icon, soft violet shadow `shadow-[0_8px_20px_-6px_rgba(139,92,246,0.5)]`. Streak title moves from display font to DM Mono (`font-mono text-base font-bold`) per Primitives.jsx spec. Subtitle color shifts from `text-green-400` to `text-fiber` (the design-system green token, `#4caf7d`). Right-side trophy icon swaps from raw `<span>` to `MaterialIcon`.
+  - **Log Food CTA** (bottom of page) replaces the prior solid-primary `<button>` with `Button variant="primary" size="lg"` (brand-gradient fill + soft violet shadow + rounded-full per Phase 2 primitive). Leading `MaterialIcon name="add_circle" fill={1}`.
+  - 4 raw `<span class="material-symbols-outlined">` instances → `MaterialIcon` primitive (chevron_left, chevron_right via IconButton; emoji_events; add_circle via Button child).
+- **Behavior preservation (verified line-by-line):**
+  - Every `useState` hook signature unchanged: `logOpen, logMeal, logs, streak, selectedDate, editEntry, waterTotalLevel`.
+  - `useProfile()` hook contract unchanged.
+  - `fetchLogs` callback unchanged — same supabase query, same `selectedDate` dependency, same error logging.
+  - Streak `useEffect` unchanged — same dedup-by-date logic, same yesterday-cutoff check, same loop.
+  - `handleDelete` and `handleEdit` flows unchanged.
+  - All derived totals (`totalCalories / Protein / Carbs / Fat / Fiber`, `calorieGoal`, `waterLevel`, `waterGoalMet`, `mealGoalMet`) computed identically.
+  - `useCelebration` hook calls unchanged with identical args.
+  - `computeMacroTargets` and `pctOf` and `macros` array unchanged.
+  - `meals` array mapping unchanged (including `unitCalories / unitProtein / unitCarbs / unitFat / unitFiber` derivations needed by the edit modal).
+  - Date navigator state machine unchanged — `goBack`, `goForward`, `isToday`, `isAtEarliest`, `dateLabel` all verbatim.
+  - Profile error fallback (blocks vs partial vs none) unchanged.
+  - Footer copy unchanged.
+  - LogFoodModal + 2 CelebrationOverlay instances at the bottom of the tree mounted with the same props.
+- **Primitives consumed:** `Button` (1), `Card` (1, on the empty-state for past dates), `IconButton` (2, for date chevrons), `MaterialIcon` (4 usages in this page; the Streak card's flame, the Streak card's trophy, the meals-header `add`, and the empty-state's `add`).
+- **Build:** `pnpm build` green in 2.9 s. Bundle deltas to be filled in post-push.
+- **Security gates:** `pnpm audit` clean, zero new deps, hardened secret-scan to be verified pre-push, no XSS sinks (zero `dangerouslySetInnerHTML` / `eval` / inline event-handler strings; the only inline-style usage is on the `aria-hidden` wrapper for the forward-chevron's hide-when-today state, which is just an opacity toggle), `vercel.json` not touched, Supabase RLS / auth / `.env` not touched.
+- **Smoke-test scope** (highest-traffic screen, deeper than 3-series):
+  - `/dashboard` logged in: page loads, all sections render, greeting reads correctly with first name + 👋
+  - Date navigator: back/forward chevrons toggle, "Today" pill appears when off-today, history floor at 30 days disables back chevron
+  - CalorieRing: live consumed/goal/burned, reward animation fires on goal-met transition
+  - MacroCard strip: 4 cards, over-warning red on carbs/fat
+  - WaterTracker: log a glass via tap → visual update + persistence
+  - Meal sections: add via "+", edit, delete-with-confirm; all four meal types use the rubric emojis (🍳 / 🥗 / 🍽️ / 🍎)
+  - Empty state: navigate to a past date with no logs → Card-wrapped empty state with "Add an entry for this day" link
+  - Streak card: gradient flame circle, mono "X day streak" title, green subtitle, trophy icon right-side; tooltip still appears on hover with the streak rules
+  - Log Food CTA: `Button` primary triggers LogFoodModal with no defaultMeal preset
+  - LogFoodModal: opens, every interaction works (food log persists, modal closes)
+  - CelebrationOverlay: hit calorie goal in test data → reward animations fire (rewardPop on badge, rewardBurst behind, rewardShimmer on title)
+  - Header (Phase 3b reskin): wordmark gradient, profile avatar, Sign out — all still working
+  - Profile menu in Header: opens, navigates to /profile
+  - Mobile viewport (390 px in DevTools): no layout breaks
+  - Tablet viewport (768 px): layout adapts cleanly
+  - Console clean apart from the known vercel.live preview-toolbar CSP block
+- **Deltas vs. plan:**
+  - **MEAL_META emojis updated.** Plan said "behavioral preservation: every prop, every callback, every data-flow contract stays the same." MEAL_META is a local constant; the emoji field is purely display. Updated to match SKILL.md §8 rubric (which is a non-negotiable). Database `meal_type` keys (`breakfast`, `lunch`, `dinner`, `snacks`) are untouched.
+  - **"Today" quick-jump kept as a raw button styled to match Badge.** Badge primitive has no `onClick` / `aria-pressed` semantics; making it clickable would either require extending the primitive or wrapping Badge in a button. Either fight is bigger than the styling gain. Used the same color tokens (bg-primary/[0.15], text-violet-300, border-primary/35, font-display) so the visual matches Badge variant="pop" exactly. Documented.
+  - **Streak card stayed as raw `<div>` with the inner card surface inlined.** Card primitive has `overflow-hidden` baked in, which would clip the streak card's tooltip (positioned absolute outside the card's bounds). Tooltip is a sibling of the card-shape, both children of an outer `relative group` wrapper. Decision: don't extend Card with an `overflow` prop in this phase per the "don't fabricate primitives in this phase" rule; keep raw div for streak only. Pickup candidate: add `overflow="visible"` prop to Card for tooltip-friendly card surfaces.
+- **Pending:** user visual + functional QA on the design/04a-dashboard preview URL across the full smoke-test scope above. Then merge.


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Production at `healtho-kohl.vercel.app` stays untouched. Ships on top of Phase 03d merge `9c54d1f`. Begins the Phase 4 page-level series.

## File changed

`apps/web/src/pages/Dashboard.jsx` — page-level chrome + section composition + typography hierarchy now match `project/ui_kits/app/Dashboard.jsx` spec. **Component-level reskins from Phase 3 are reused unchanged.**

## Behavioral preservation (the critical guarantee)

This is the highest-traffic screen in the app. **Zero behavioral changes by design**:

- Every `useState` hook signature unchanged
- `useProfile` contract unchanged
- `fetchLogs` callback + supabase query verbatim
- Streak `useEffect` verbatim (dedup-by-date + yesterday-cutoff + consecutive-days loop)
- `handleDelete` + `handleEdit` flows verbatim
- All derived totals computed identically
- `useCelebration` hook calls verbatim
- `meals[]` mapping verbatim (including `unitCalories/Protein/Carbs/Fat/Fiber` for edit modal)
- Date navigator state machine verbatim
- Profile error fallback (blocks vs partial vs none) verbatim
- LogFoodModal + 2 CelebrationOverlay mounts verbatim

## Visual changes

| What | Change |
|---|---|
| **MEAL_META emojis** | 🌅/☀️/🌙/🍎 → 🍳/🥗/🍽️/🍎 per SKILL.md §8 emoji palette rubric |
| **Greeting** | `text-3xl font-extrabold tracking-[-0.02em]` with first name in `text-gradient` (Phase 1 token); subtitle `text-slate-400` |
| **Date chevrons** | raw buttons → `IconButton variant=\"plain\" size=\"sm\"` |
| **\"Today\" pill** | raw button restyled to match `Badge variant=\"pop\"` (raw button kept because Badge isn't clickable; documented) |
| **Meals header \"+ Log food\"** | raw text link → `MaterialIcon` + SKILL.md hover-underline + `--tap-ring` focus ring |
| **Empty-state card** | raw `<div>` shell → `Card padding=\"lg\" radius=\"xl\"` primitive |
| **Streak flame** | slate emoji box → **brand-gradient round circle**, 44 px, `MaterialIcon name=\"local_fire_department\" fill={1}` white, soft violet shadow |
| **Streak title** | `text-sm font-bold` → **`font-mono text-base font-bold`** per Primitives.jsx spec |
| **Streak subtitle** | `text-green-400` → `text-fiber` (semantic token, same color) |
| **Streak trophy + flame** | raw `<span>` → `MaterialIcon` |
| **Log Food CTA** | solid-primary `<button>` → **`Button variant=\"primary\" size=\"lg\"`** (brand-gradient + violet shadow + rounded-full) with `MaterialIcon name=\"add_circle\" fill={1}` leading |

## Primitives consumed

`Button` (1) · `Card` (1) · `IconButton` (2) · `MaterialIcon` (4 in this page)

## Visual + functional QA — wider than 3-series, this is the highest-traffic screen

🔗 **Preview:** [healtho-git-design-04a-dashboard-ayushkapoor11s-projects.vercel.app](https://healtho-git-design-04a-dashboard-ayushkapoor11s-projects.vercel.app/) (URL active once Vercel finishes)

### Page-render checks
- [ ] **`/dashboard` logged in** — page loads, all sections render
- [ ] **Greeting** reads `Good morning/afternoon/evening, <FirstName> 👋` with the first name in brand gradient
- [ ] **Date navigator**: chevrons render as IconButtons, \"Today\" pill appears when off-today
- [ ] **CalorieRing** still renders with the Phase 3a remaining-first arc
- [ ] **MacroCard strip** — 4 chips (Protein / Carbs / Fat / Fiber)
- [ ] **WaterTracker** — 8 SVG glasses
- [ ] **Meals header** — `+ Log food` inline trigger has add icon + hover-underline
- [ ] **Meal sections** — all four render with the **new rubric emojis** (🍳 🥗 🍽️ 🍎). Verify breakfast in particular (was 🌅, now 🍳)
- [ ] **Streak card** — gradient flame circle (purple-pink-cyan) on left, mono \"X day streak\" title, green subtitle, trophy icon right; tooltip still appears on hover
- [ ] **Log Food CTA** at bottom — gradient button with `add_circle` icon, runs full width

### Interaction checks
- [ ] **Date back/forward** — chevrons toggle, history floor at 30 days disables back chevron
- [ ] **\"Today\" pill** — clicking jumps to today
- [ ] **CalorieRing reward** — log enough food to push consumed ≥ goal → center number runs `rewardPop`
- [ ] **WaterTracker** — tap a glass → fills + persists (localStorage)
- [ ] **Meal section: add** — `+` button opens LogFoodModal with the meal preset
- [ ] **Meal section: edit** — pencil opens LogFoodModal in edit mode, save persists
- [ ] **Meal section: delete** — trash → confirm row → \"Yes, delete\" → entry disappears, macros recalc
- [ ] **Empty state** — navigate to a past date with no logs → Card-wrapped empty state with \"Add an entry for this day\" link
- [ ] **Log Food CTA** at bottom — opens LogFoodModal with no meal preset
- [ ] **CelebrationOverlay** — fill 8 glasses → cyan variant fires; hit calorie goal across all three meal types → violet variant fires
- [ ] **Header profile menu** — avatar Link → `/profile`; Sign out → `/login`

### Mobile + tablet
- [ ] **Mobile viewport (390 px)** — no overflow, all interactions reachable, gradient flame circle still visible
- [ ] **Tablet viewport (768 px)** — layout adapts cleanly, content stays centered at `max-w-[520px]`

### Console
- [ ] No errors apart from the known `vercel.live/_next-live/feedback/feedback.js` preview-toolbar CSP block (pre-existing, intentionally not fixed)

## Security gates

| Gate | Status |
|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS |
| Zero new npm deps | ✅ PASS — lockfile unchanged |
| No XSS sinks | ✅ PASS — zero `dangerouslySetInnerHTML` / `eval` / inline event-handler strings |
| Hardened secret-scan | ✅ PASS |
| Same-origin assets | ✅ PASS — no new external origins |
| `vercel.json` untouched | ✅ PASS |
| Supabase / `.env` untouched | ✅ PASS |

## Build numbers

`pnpm build` green in 2.9 s. Bundle deltas in the next-merged log entry once measured.

## Deltas vs. plan

1. **MEAL_META emojis updated.** Plan said behavioral preservation: every prop, every callback, every data-flow contract. MEAL_META is a local display constant; the database `meal_type` keys (`breakfast`/`lunch`/`dinner`/`snacks`) are untouched. Updated emojis to match SKILL.md §8 rubric (non-negotiable).
2. **\"Today\" quick-jump kept as raw button styled to match Badge.** Badge primitive has no `onClick`/`aria-pressed` semantics; making it clickable would either extend the primitive or wrap it in a button. Used the same color tokens as `Badge variant=\"pop\"` for visual parity.
3. **Streak card stayed as raw `<div>`.** Card primitive's `overflow-hidden` would clip the tooltip (positioned absolute outside the card's bounds). Tooltip is a sibling of the card-shape, both children of an outer `relative group` wrapper. Decision: don't extend Card with an `overflow` prop in this phase per the \"don't fabricate primitives\" rule. Pickup candidate: `Card overflow=\"visible\"` prop.

## Phase 03d closeout (rides on this PR's log commit)

The Phase 03d closeout (PR #13 merge SHA `9c54d1f` + user same-origin Network-tab QA result) is appended to `docs/design-system-execution-plan.md` in this same commit. **Pickup A is now officially CLOSED.**

## Known QA noise (NOT a regression)

`vercel.live/_next-live/feedback/feedback.js` CSP block on previews — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)