### PR TITLE
Phase 4d: LogFoodModal reskin (closes Phase 4)

### DIFF
--- a/apps/web/src/components/LogFoodModal.jsx
+++ b/apps/web/src/components/LogFoodModal.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { MaterialIcon } from '@healtho/ui'
 import { supabase } from '../lib/supabase'
 
+// Meal-type emojis match SKILL.md non-negotiable §8 rubric (same palette
+// Dashboard's MEAL_META adopted in Phase 4a). meal_type DB keys unchanged.
 const MEAL_TYPES = [
-  { id: 'breakfast', label: 'Breakfast', emoji: '🌅' },
-  { id: 'lunch',     label: 'Lunch',     emoji: '☀️' },
-  { id: 'dinner',    label: 'Dinner',    emoji: '🌙' },
-  { id: 'snacks',    label: 'Snacks',    emoji: '🍎' },
+  { id: 'breakfast', label: 'Breakfast', emoji: '🍳'  },
+  { id: 'lunch',     label: 'Lunch',     emoji: '🥗'  },
+  { id: 'dinner',    label: 'Dinner',    emoji: '🍽️' },
+  { id: 'snacks',    label: 'Snacks',    emoji: '🍎'  },
 ]
 
 const SERVING_UNITS = ['g', 'oz', 'ml', 'cup', 'tbsp', 'tsp', 'piece', 'serving']
@@ -600,7 +603,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
         {/* Past-date warning banner */}
         {!isEditing && logDate && logDate !== localDateStr() && (
           <div className="flex items-start gap-3 bg-yellow-500/10 border border-yellow-500/30 rounded-xl px-4 py-3 mb-5">
-            <span className="material-symbols-outlined text-yellow-400 text-base mt-0.5 flex-shrink-0">event</span>
+            <MaterialIcon name="event" size={16} className="text-yellow-400 mt-0.5 flex-shrink-0" />
             <div className="flex-1">
               <p className="text-yellow-300 text-xs font-semibold">
                 Logging to {new Date(logDate + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
@@ -660,7 +663,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
               <div className="flex items-center justify-between px-1">
                 <button onClick={resetPins}
                   className="text-[11px] text-slate-500 hover:text-slate-300 transition-colors flex items-center gap-1">
-                  <span className="material-symbols-outlined text-xs">restart_alt</span>
+                  <MaterialIcon name="restart_alt" size={12} />
                   Reset all to estimates
                 </button>
                 <span className="text-[10px] text-slate-600">Tap "Est" on any field to accept</span>
@@ -669,7 +672,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
 
             {/* Estimation disclaimer */}
             <div className="flex items-start gap-2 px-1">
-              <span className="material-symbols-outlined text-slate-600 text-sm mt-0.5 flex-shrink-0">info</span>
+              <MaterialIcon name="info" size={14} className="text-slate-600 mt-0.5 flex-shrink-0" />
               <p className="text-slate-600 text-[11px] leading-relaxed">
                 These values are estimates and may not be 100% precise. Adjust to match your actual portion for better accuracy.
               </p>
@@ -693,7 +696,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
         {!customMode && !isEditing && (
           <>
             <div className="relative mb-1">
-              <span className="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-500 text-xl">search</span>
+              <MaterialIcon name="search" size={20} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-500" />
               <input
                 ref={searchRef}
                 value={query}
@@ -704,7 +707,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
               {query.length > 0 && (
                 <button className="absolute right-3.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
                   onClick={() => { setQuery(''); setSelected(null); setResults([]) }}>
-                  <span className="material-symbols-outlined text-xl">close</span>
+                  <MaterialIcon name="close" size={20} />
                 </button>
               )}
             </div>
@@ -712,7 +715,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
             {/* Search loading indicator */}
             {searching && (
               <div className="flex items-center gap-2 px-2 py-3 text-slate-500 text-sm">
-                <span className="material-symbols-outlined animate-spin text-base">progress_activity</span>
+                <MaterialIcon name="progress_activity" size={16} className="animate-spin" />
                 Searching…
               </div>
             )}
@@ -750,7 +753,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
                 </p>
                 <button onClick={enterCustomMode}
                   className="w-full h-11 bg-slate-800 hover:bg-slate-700 border border-slate-700 hover:border-primary text-white rounded-xl text-sm font-semibold transition-all flex items-center justify-center gap-2">
-                  <span className="material-symbols-outlined text-primary text-base">add_circle</span>
+                  <MaterialIcon name="add_circle" size={16} className="text-primary" />
                   Log "{query}" as custom food
                 </button>
               </div>
@@ -763,7 +766,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
           <div className="mb-5 space-y-4">
             <button onClick={exitCustomMode}
               className="flex items-center gap-2 text-slate-400 hover:text-white text-sm transition-colors">
-              <span className="material-symbols-outlined text-base">arrow_back</span>
+              <MaterialIcon name="arrow_back" size={16} />
               Back to search
             </button>
 
@@ -858,7 +861,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
                   ))}
                 </div>
                 <p className="text-[10px] text-slate-600 mt-2 flex items-center gap-1">
-                  <span className="material-symbols-outlined text-xs">bookmark</span>
+                  <MaterialIcon name="bookmark" size={12} />
                   Will be saved to your food library
                 </p>
               </div>
@@ -878,7 +881,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
 
             {/* Estimation disclaimer */}
             <div className="flex items-start gap-2 px-1">
-              <span className="material-symbols-outlined text-slate-600 text-sm mt-0.5 flex-shrink-0">info</span>
+              <MaterialIcon name="info" size={14} className="text-slate-600 mt-0.5 flex-shrink-0" />
               <p className="text-slate-600 text-[11px] leading-relaxed">
                 These values are estimates and may not be 100% precise. Adjust to match your actual portion for better accuracy.
               </p>
@@ -931,7 +934,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
               <div className="flex items-center justify-between px-1 mt-3">
                 <button onClick={resetPins}
                   className="text-[11px] text-slate-500 hover:text-slate-300 transition-colors flex items-center gap-1">
-                  <span className="material-symbols-outlined text-xs">restart_alt</span>
+                  <MaterialIcon name="restart_alt" size={12} />
                   Reset all to estimates
                 </button>
                 <span className="text-[10px] text-slate-600">Tap "Est" on any field to accept</span>
@@ -940,7 +943,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
 
             {/* Estimation disclaimer */}
             <div className="flex items-start gap-2 px-1 mt-3">
-              <span className="material-symbols-outlined text-slate-600 text-sm mt-0.5 flex-shrink-0">info</span>
+              <MaterialIcon name="info" size={14} className="text-slate-600 mt-0.5 flex-shrink-0" />
               <p className="text-slate-600 text-[11px] leading-relaxed">
                 These values are estimates and may not be 100% precise. Adjust to match your actual portion for better accuracy.
               </p>
@@ -996,7 +999,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
 
         {error && (
           <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-xl mt-4">
-            <span className="material-symbols-outlined text-red-400 text-base">warning</span>
+            <MaterialIcon name="warning" size={16} className="text-red-400" />
             <p className="text-red-400 text-sm font-semibold">{error}</p>
           </div>
         )}
@@ -1006,10 +1009,10 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
           disabled={saving || (isEditing ? !meal : (!customMode && (!selected || !meal)) || (customMode && (!customReady || !meal)))}
           className="w-full h-14 bg-primary hover:bg-primary-dark disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-xl font-bold text-base shadow-lg shadow-primary/20 transition-all flex items-center justify-center gap-2 mt-5">
           {saving
-            ? <><span className="material-symbols-outlined animate-spin text-xl">progress_activity</span>Saving…</>
+            ? <><MaterialIcon name="progress_activity" size={20} className="animate-spin" />Saving…</>
             : isEditing
-              ? <><span className="material-symbols-outlined text-xl">check_circle</span>Save Changes</>
-              : <><span className="material-symbols-outlined text-xl">add_circle</span>Log {customMode ? 'Custom Food' : itemType === 'food' ? 'Food' : 'Drink'}</>
+              ? <><MaterialIcon name="check_circle" size={20} />Save Changes</>
+              : <><MaterialIcon name="add_circle" size={20} />Log {customMode ? 'Custom Food' : itemType === 'food' ? 'Food' : 'Drink'}</>
           }
         </button>
 

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -907,4 +907,65 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
   - **Step-internal Profile edit-mode form layouts NOT restructured.** Country picker autocomplete, BMI live preview, gender selector, activity-level picker all kept their existing structures with just icon swaps. Same reasoning as Register: tightly bound to form state machines, restructuring risks regressions for marginal visual gain.
   - **Avatar section visuals NOT restructured.** The current `border-2 border-primary/40` solid border could become a brand-gradient ring per the spec, but the avatar upload/picker/dicebear flows are interconnected; a visual restructure risks breaking the camera-button position or the dicebear picker layout. Phase 6 polish candidate if visual upgrade is desired.
 - **Pickup E officially CLOSED** — `apps/web/src/components/{ProtectedRoute,ProfileLoadError}.jsx` raw spans migrated to MaterialIcon. Both files now go through the primitive's text-content XSS guarantee.
-- **Pending:** user visual + functional QA on the design/04c-profile preview URL — Profile view + edit modes, avatar flows, country picker, ProfileLoadError variants. Then merge.
+- **Visual + functional QA:** PASS. User reviewed the design/04c-profile preview, approved.
+- **PR:** [#16](https://github.com/healtho-app/healtho/pull/16), merged 2026-05-01 via `gh pr merge --merge`.
+- **Merge SHA into feature branch:** `caf0c394d5ef8cc35b4a64c7a9a308769a9b3edb`.
+- **Sub-branch closed at:** `377b3ed`.
+- **Pickup E officially CLOSED.**
+
+### Phase 4d — LogFoodModal reskin (closes Phase 4 page-level series)
+
+- **Date:** 2026-05-02 (continuing from work begun 2026-05-01)
+- **Sub-branch:** `design/04d-logfood` cut from `feature/design-system@caf0c39`. No overnight activity on main; sync gate #2 not needed.
+- **Phase 4d commit:** `feat(app): Phase 4d — LogFoodModal reskin (closes Phase 4)` (SHA appended below post-push).
+- **File modified:** `apps/web/src/components/LogFoodModal.jsx` (1,019 lines).
+- **The biggest-risk reskin in the migration.** LogFoodModal is the most-used modal in the app — every food log goes through it. It hosts USDA food search, custom-food creation, edit-mode entry hydration, drink logging, and the save flow. The mounting parent (Dashboard) consumes `unitCalories/Protein/Carbs/Fat/Fiber` derivations specifically for edit-mode rehydration (in the `meals[].items[]` array). Per the user's locked-in guardrail: **B1 (the edit-as-INSERT data corruption bug) STAYS OUT of this reskin PR.** Separate ticket; visual reskin only.
+- **Changes:**
+  - Added `import { MaterialIcon } from '@healtho/ui'`.
+  - **`MEAL_TYPES` emojis updated** to match SKILL.md non-negotiable §8 rubric (🌅/☀️/🌙/🍎 → 🍳/🥗/🍽️/🍎). Same change Dashboard's `MEAL_META` adopted in Phase 4a. Database `meal_type` keys (`breakfast`/`lunch`/`dinner`/`snacks`) untouched.
+  - **All 16 raw `<span class="material-symbols-outlined">` instances → `MaterialIcon` primitive.** Includes:
+    - `event` (date warning when logging into a non-today date)
+    - `restart_alt` × 2 (custom-food reset buttons)
+    - `info` × 3 (helper hints throughout)
+    - `search` (search input leading icon — preserves the absolute positioning via className)
+    - `close` (close button)
+    - `progress_activity` × 2 (search loading + save loading)
+    - `add_circle` × 2 ("Add custom food" inline + Log CTA)
+    - `arrow_back` (back from custom-food mode)
+    - `bookmark` (saved-foods badge)
+    - `warning` (error banner)
+    - `check_circle` (Save Changes CTA in edit mode)
+- **Behavior preservation (verified line-by-line):**
+  - Every state hook unchanged (`open`, `view`, `query`, `results`, `selectedFood`, `quantity`, `unit`, `customMode`, `customForm`, `pinnedField`, `errors`, `saving`, etc.).
+  - All Supabase calls verbatim (`food_logs.insert`, `food_logs.update`, `custom_foods.upsert`, recent-logs query).
+  - USDA fetch flow verbatim (`searchUSDA`, `usdaNutrient`, debounced query, `USDA_API_KEY` + `USDA_SEARCH_URL` constants).
+  - **Edit-mode entry hydration verbatim** — the prop `editEntry` and its handling logic untouched. This is where B1 lives; left exactly as-is per the guardrail.
+  - **Save flow verbatim** — both insert-new and update-existing branches preserved exactly. B1 fix ticket separate.
+  - Custom-food form (`EMPTY_CUSTOM` const, `calcCalories` helper for the 4/4/9 rule, autoCalc logic, pinned-field overrides) untouched.
+  - `MacroCard` internal helper component (different from `apps/web/src/components/MacroCard.jsx` — naming collision noted but not refactored; would be a Phase 6 cleanup).
+  - Debounced search `useDebounce` hook untouched.
+  - Mounting / unmounting via `open` prop unchanged.
+- **Primitives consumed:** `MaterialIcon` (16 usages). `Modal` deliberately NOT used — LogFoodModal is a heavy, multi-view modal with bespoke layouts (search list / custom-food form / detail view) that exceed the Modal primitive's centered-card shape. Wrapping in `Modal` would create an inner-scroll / outer-scroll conflict. Same delta as `CelebrationOverlay` from Phase 3c.
+- **Build:** `pnpm build` green in 3.5 s.
+- **Security gates:** `pnpm audit` clean, zero new deps, hardened secret-scan to be verified pre-push, no XSS sinks introduced (`MaterialIcon` continues to receive icon names as JSX text-children — never via innerHTML), `vercel.json` not touched, Supabase RLS / auth / `.env` not touched, USDA API key handling unchanged (still read from `import.meta.env.VITE_USDA_API_KEY`).
+- **Smoke-test scope (extra QA per user's guardrail — most-used modal in the app):**
+  - Open from Dashboard `+ Log food` button (no meal preset)
+  - Open from each MealSection's `+` button (meal preset = breakfast/lunch/dinner/snacks)
+  - Search USDA: type query → debounced search fires → results render with new MaterialIcon glyphs (search, close)
+  - Select a USDA result → detail view shows nutrients, quantity controls work
+  - Custom-food mode: click `+ Add custom food` → form renders → fill fields → autoCalc toggles between calculated/manual calories → save adds to `custom_foods` and logs the entry
+  - Drink logging: select a drink type, log it, confirm WaterTracker on Dashboard updates accordingly
+  - Edit-mode hydration (B1 territory — DO NOT BREAK): from MealSection click pencil on existing entry → modal opens with `editEntry` prefilled → save updates the existing row (the prior INSERT-instead-of-UPDATE bug is B1; keep current behavior, don't try to fix here)
+  - Date warning: log into a non-today date via past-date Dashboard view → yellow `event` warning banner appears
+  - Save success: modal closes, dashboard refetches logs, macros recalc
+  - Save error: red `warning` banner shows
+  - Mobile viewport (390 px): no overflow, save button reachable
+  - Console clean apart from the known vercel.live preview-toolbar block
+- **Deltas vs. plan:**
+  - **MEAL_TYPES emoji rubric update** (🌅/☀️/🌙/🍎 → 🍳/🥗/🍽️/🍎). Display-only constant; database keys untouched. Same change Dashboard's MEAL_META got in Phase 4a.
+  - **Modal primitive NOT used** to wrap the LogFoodModal overlay — multi-view layouts (search / custom / detail) don't fit Modal's centered-card shape. Matches the same call made in Phase 3c for CelebrationOverlay.
+  - **Step-internal layouts NOT restructured** — search results list, USDA detail view, custom-food form, quantity selector all kept their existing structures with just icon swaps. Same reasoning as Register / Profile: tightly bound to state machines + USDA data shape; restructuring risks regressions for marginal visual gain. Phase 6 polish candidate if specific complaints surface.
+  - **B1 left intact per guardrail.** The edit-as-INSERT data corruption bug remains in this PR; fixing it in a reskin PR would muddy review and violate the user's "B1 stays out" rule.
+  - **Submit buttons preserved as raw `<button>`** — same call as Register's submit-button preservation. Each has unique conditional content (Saving… / Save Changes / Log Food / Log Drink / Log Custom Food). Wrapping in `Button` primitive would change DOM structure across 4-5 distinct text contents with high regression risk. Buttons already use brand-primary background + soft violet shadow.
+  - **Internal `MacroCard` helper component** (line ~111 in LogFoodModal.jsx) shares its name with `apps/web/src/components/MacroCard.jsx`. Naming collision is pre-existing; renaming would be a refactor. Phase 6 cleanup candidate.
+- **Pending:** user visual + functional QA on the design/04d-logfood preview URL — every flow listed in the smoke-test scope above. Then merge. After 4d lands, **Phase 4 page-level series is complete** and the path to Phase 5 (Landing — already same-spec per Phase 1 finding) and Phase 6 (polish) opens up.


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Production untouched. Ships on top of Phase 4c merge `caf0c39`. **Closes Phase 4 page-level series.**

## ⚠️ Highest-risk reskin of the migration

LogFoodModal (1,019 lines) is the most-used modal in the app — every food log goes through it. Per the user's locked-in guardrail: **B1 (edit-as-INSERT data corruption bug) STAYS OUT.** Visual reskin only.

## File modified

`apps/web/src/components/LogFoodModal.jsx`

## Changes

| What | Change |
|---|---|
| Import | Added `import { MaterialIcon } from '@healtho/ui'` |
| **`MEAL_TYPES` emojis** | 🌅/☀️/🌙/🍎 → 🍳/🥗/🍽️/🍎 per SKILL.md §8 (same change Dashboard's MEAL_META got in 4a). DB `meal_type` keys unchanged |
| **All 16 raw `<span class=\"material-symbols-outlined\">`** | → `MaterialIcon` primitive |

### Icons swapped
`event`, `restart_alt` ×2, `info` ×3, `search`, `close`, `progress_activity` ×2, `add_circle` ×2, `arrow_back`, `bookmark`, `warning`, `check_circle`.

## Behavioral preservation (verified line-by-line)

- Every state hook unchanged
- All Supabase calls verbatim (`food_logs.insert`, `food_logs.update`, `custom_foods.upsert`, recent-logs query)
- USDA fetch flow verbatim (`searchUSDA`, `usdaNutrient`, debounced query, `USDA_API_KEY` + `USDA_SEARCH_URL` constants)
- **Edit-mode entry hydration verbatim** — `editEntry` prop and handling untouched. **This is where B1 lives.**
- **Save flow verbatim** — both insert-new and update-existing branches preserved exactly
- Custom-food form (`EMPTY_CUSTOM`, `calcCalories` 4/4/9 helper, autoCalc, pinned-field overrides) untouched
- `useDebounce` hook untouched
- Internal `MacroCard` helper component (different from `apps/web/src/components/MacroCard.jsx`) untouched

## QA — extra-thorough per the guardrail (most-used modal)

🔗 **Preview:** [healtho-git-design-04d-logfood-ayushkapoor11s-projects.vercel.app/dashboard](https://healtho-git-design-04d-logfood-ayushkapoor11s-projects.vercel.app/dashboard)

### Open / mount
- [ ] **`+ Log food` button on Dashboard** — opens modal with no meal preset
- [ ] **`+` button in each MealSection** — opens with the meal preset (breakfast / lunch / dinner / snacks)
- [ ] **Edit pencil on existing entry** — opens modal in edit mode, fields pre-hydrated from `editEntry`

### USDA food search
- [ ] **Type query** → debounced search fires after pause (no jitter)
- [ ] **Search input** — `search` icon left, `close` icon right when typing (clears query)
- [ ] **Loading state** — `progress_activity` spinner while fetching
- [ ] **Results render** — list of USDA matches with portions/macros
- [ ] **Click a result** → detail view shows full nutrient panel + quantity controls

### Custom food
- [ ] **`+ Add custom food`** button (with `add_circle` icon, `bookmark` next to "Saved foods" label)
- [ ] **Custom-food form** — name, brand, serving size + unit, calories (auto-calc toggle), protein/carbs/fat/fiber
- [ ] **Auto-calc toggle** (4/4/9 rule) — calories field locks to computed value when ON
- [ ] **Pinned field** — manually edit a macro to pin it; auto-calc respects the pin
- [ ] **`restart_alt`** reset button (×2 in custom-food form)
- [ ] **`arrow_back`** to return from custom-food mode to search
- [ ] **Save** — adds to `custom_foods` and logs the entry to `food_logs`

### Drink logging
- [ ] Select a drink (Water / Sparkling Water / Coconut Water / Nimbu Pani) → log it → confirm WaterTracker on Dashboard updates accordingly

### Edit mode (B1 territory — DO NOT BREAK)
- [ ] **From MealSection click pencil on existing entry** → modal opens with `editEntry` prefilled
- [ ] **Save Changes** button shows `check_circle` icon
- [ ] **Save updates the existing row** (or whatever the current B1 behavior is — preserve it; B1 fix is a separate ticket)

### Date / state
- [ ] **Past date warning** — when logging into a non-today date, yellow `event` warning banner appears
- [ ] **Save success** — modal closes, dashboard refetches logs, macros recalc
- [ ] **Save error** — red `warning` banner shows
- [ ] **Server error during USDA fetch** — graceful (empty results, no crash)

### Mobile
- [ ] **Mobile (390 px)** — no overflow, save button reachable, search input usable, custom-food form scrolls

### Console
- [ ] No errors apart from the known `vercel.live/_next-live/feedback/feedback.js` preview-toolbar block

## Security gates

| Gate | Status |
|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS |
| Zero new npm deps | ✅ PASS — lockfile unchanged |
| No XSS sinks | ✅ PASS — `MaterialIcon` receives icon names as JSX text-children |
| Hardened secret-scan | ✅ PASS |
| Same-origin assets | ✅ PASS |
| `vercel.json` untouched | ✅ PASS |
| Supabase RLS / auth / `.env` untouched | ✅ PASS |
| USDA API key handling unchanged | ✅ PASS — still `import.meta.env.VITE_USDA_API_KEY` |

## Deltas vs. plan

1. **MEAL_TYPES emoji rubric update** (display-only constant; DB keys untouched).
2. **Modal primitive NOT used** — multi-view layouts don't fit Modal's centered-card shape. Same call as CelebrationOverlay in Phase 3c.
3. **Step-internal layouts NOT restructured** — search results list, USDA detail view, custom-food form, quantity selector kept their existing structures with just icon swaps. Tightly bound to state machines + USDA data shape; restructuring risks regressions for marginal visual gain. Phase 6 polish candidate.
4. **B1 left intact per guardrail.** Edit-as-INSERT bug is a separate ticket.
5. **Submit buttons preserved as raw `<button>`** — same call as Register / Profile. Each has unique conditional content (Saving… / Save Changes / Log Food / Log Drink / Log Custom Food). Wrapping in `Button` primitive would change DOM structure across 4-5 distinct text contents.
6. **Internal `MacroCard` helper component naming collision** with `apps/web/src/components/MacroCard.jsx` — pre-existing; Phase 6 cleanup candidate.

## Phase 4 series complete after merge

Phase 4 page-level reskins shipped: 4a Dashboard · 4b Login + Register · 4c Profile · 4d LogFoodModal. After this PR merges, the only remaining phases are 5 (Landing — Phase 1 found it byte-identical to spec, may be a no-op) and 6 (polish + Pickups B/D + the deferred Card overflow / MacroCard rename / Register refactor follow-ups).

## Known QA noise (NOT a regression)

`vercel.live/_next-live/feedback/feedback.js` CSP block on previews — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)