### PR TITLE
Phase 5: landing polish (4 icons + reduce-motion guards)

### DIFF
--- a/apps/web/src/components/landing/BackgroundMedia.jsx
+++ b/apps/web/src/components/landing/BackgroundMedia.jsx
@@ -5,6 +5,11 @@ import { useEffect, useRef, useState } from 'react'
  * Supports video (with poster fallback) or image backgrounds.
  * Always renders a dark overlay for text readability.
  *
+ * Reduce-motion: when `prefers-reduced-motion: reduce` is set, video
+ * autoplay is suppressed and the poster image is rendered instead. This
+ * mirrors the SKILL.md non-negotiable §15 ("respect prefers-reduced-motion")
+ * and Phase 1's --dur-* token-based motion budget.
+ *
  * @param {'video'|'image'} type
  * @param {string} src        — path to video or image
  * @param {string} poster     — poster image (video only, also used as fallback)
@@ -13,21 +18,44 @@ import { useEffect, useRef, useState } from 'react'
 export default function BackgroundMedia({ type = 'image', src, poster, opacity = 0.65 }) {
   const videoRef = useRef(null)
   const [videoFailed, setVideoFailed] = useState(false)
+  const [reduceMotion, setReduceMotion] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  })
+
+  // Live-track changes to the user's motion preference (e.g., toggling the
+  // OS-level Reduce Motion setting while the page is open).
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return undefined
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const onChange = (e) => setReduceMotion(e.matches)
+    if (mql.addEventListener) {
+      mql.addEventListener('change', onChange)
+      return () => mql.removeEventListener('change', onChange)
+    }
+    // Older Safari fallback
+    mql.addListener(onChange)
+    return () => mql.removeListener(onChange)
+  }, [])
+
+  // Treat reduce-motion as "video unavailable" — falls through to the poster
+  // image rendering branch below.
+  const showVideo = type === 'video' && !videoFailed && !reduceMotion
 
   useEffect(() => {
-    if (type !== 'video' || !videoRef.current) return
+    if (!showVideo || !videoRef.current) return
 
     // Attempt play — browsers may block even muted autoplay in rare cases
     const playPromise = videoRef.current.play()
     if (playPromise !== undefined) {
       playPromise.catch(() => setVideoFailed(true))
     }
-  }, [type])
+  }, [showVideo])
 
   return (
     <div className="absolute inset-0 z-0 overflow-hidden">
       {/* Video or image layer */}
-      {type === 'video' && !videoFailed ? (
+      {showVideo ? (
         <video
           ref={videoRef}
           autoPlay

--- a/apps/web/src/components/landing/DashboardPreview.jsx
+++ b/apps/web/src/components/landing/DashboardPreview.jsx
@@ -1,3 +1,5 @@
+import { MaterialIcon } from '@healtho/ui'
+
 export default function DashboardPreview() {
   const macros = [
     { label: 'Protein', value: '32g', color: 'bg-protein/15 text-protein' },
@@ -38,7 +40,7 @@ export default function DashboardPreview() {
         {/* Streak card */}
         <div className="flex items-center gap-3 bg-white/[0.04] border border-white/[0.06] rounded-xl px-4 py-3">
           <div className="w-10 h-10 rounded-full bg-brand-gradient flex items-center justify-center text-lg">
-            <span className="material-symbols-outlined text-white text-xl">local_fire_department</span>
+            <MaterialIcon name="local_fire_department" size={20} className="text-white" />
           </div>
           <div>
             <div className="text-sm font-semibold text-white">7 Day Streak</div>

--- a/apps/web/src/components/landing/FeaturesSection.jsx
+++ b/apps/web/src/components/landing/FeaturesSection.jsx
@@ -1,3 +1,4 @@
+import { MaterialIcon } from '@healtho/ui'
 import BackgroundMedia from './BackgroundMedia'
 
 const features = [
@@ -62,7 +63,7 @@ export default function FeaturesSection() {
               className="group bg-black/40 backdrop-blur-md border border-white/[0.08] rounded-2xl p-6 hover:border-primary/30 transition-all duration-300 hover:-translate-y-1"
             >
               <div className="w-11 h-11 rounded-xl bg-primary/15 flex items-center justify-center mb-4 group-hover:bg-primary/25 transition-colors duration-300">
-                <span className="material-symbols-outlined text-primary text-xl">{icon}</span>
+                <MaterialIcon name={icon} size={20} className="text-primary" />
               </div>
               <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
               <p className="text-sm text-white leading-relaxed">{desc}</p>

--- a/apps/web/src/components/landing/LandingNavbar.jsx
+++ b/apps/web/src/components/landing/LandingNavbar.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 
 const navLinks = [
   { label: 'Features', to: '/features' },
@@ -60,10 +61,9 @@ export default function LandingNavbar() {
             onClick={() => setMenuOpen(prev => !prev)}
             className="md:hidden flex items-center justify-center w-9 h-9 rounded-lg hover:bg-white/[0.06] transition-colors"
             aria-label="Toggle menu"
+            aria-expanded={menuOpen}
           >
-            <span className="material-symbols-outlined text-white text-2xl">
-              {menuOpen ? 'close' : 'menu'}
-            </span>
+            <MaterialIcon name={menuOpen ? 'close' : 'menu'} size={24} className="text-white" />
           </button>
         </div>
       </div>

--- a/apps/web/src/components/landing/PricingSection.jsx
+++ b/apps/web/src/components/landing/PricingSection.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 
 const plans = [
   {
@@ -100,7 +101,7 @@ export default function PricingSection() {
               <ul className="flex-1 space-y-3 mb-6">
                 {features.map(f => (
                   <li key={f} className="flex items-start gap-2.5 text-sm text-white">
-                    <span className="material-symbols-outlined text-primary text-base mt-0.5">check_circle</span>
+                    <MaterialIcon name="check_circle" size={16} className="text-primary mt-0.5" />
                     {f}
                   </li>
                 ))}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -49,7 +49,7 @@
 
 .landing-fade-up {
   opacity: 0;
-  animation: fadeUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: fadeUp var(--dur-reveal) cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 .landing-delay-1 { animation-delay: 0.1s; }
@@ -57,8 +57,20 @@
 .landing-delay-3 { animation-delay: 0.35s; }
 .landing-delay-4 { animation-delay: 0.5s; }
 
+/* Float is a continuous decorative idle animation; suppress entirely on
+   prefers-reduced-motion so it never loops in the background. */
 .landing-float {
   animation: float 5s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .landing-float { animation: none; }
+  /* Zero out the staggered entrance delays so content appears immediately
+     in its final state — no flash, no jank. --dur-reveal already collapses
+     to 0 ms via tokens.css, so the animation finishes before any delay. */
+  .landing-delay-1,
+  .landing-delay-2,
+  .landing-delay-3,
+  .landing-delay-4 { animation-delay: 0ms; }
 }
 
 /* ── Celebration animations ──────────────────────────────── */

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -968,4 +968,52 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
   - **B1 left intact per guardrail.** The edit-as-INSERT data corruption bug remains in this PR; fixing it in a reskin PR would muddy review and violate the user's "B1 stays out" rule.
   - **Submit buttons preserved as raw `<button>`** — same call as Register's submit-button preservation. Each has unique conditional content (Saving… / Save Changes / Log Food / Log Drink / Log Custom Food). Wrapping in `Button` primitive would change DOM structure across 4-5 distinct text contents with high regression risk. Buttons already use brand-primary background + soft violet shadow.
   - **Internal `MacroCard` helper component** (line ~111 in LogFoodModal.jsx) shares its name with `apps/web/src/components/MacroCard.jsx`. Naming collision is pre-existing; renaming would be a refactor. Phase 6 cleanup candidate.
-- **Pending:** user visual + functional QA on the design/04d-logfood preview URL — every flow listed in the smoke-test scope above. Then merge. After 4d lands, **Phase 4 page-level series is complete** and the path to Phase 5 (Landing — already same-spec per Phase 1 finding) and Phase 6 (polish) opens up.
+- **Visual + functional QA:** PASS. User exercised LogFoodModal end-to-end on the preview, including a USDA search that surfaced a 400 (Bread (White) parens-rejection — verified pre-existing API quirk, NOT a Phase 4d regression since the diff didn't touch USDA fetch logic). User merged after the verification.
+- **PR:** [#17](https://github.com/healtho-app/healtho/pull/17), merged 2026-05-02 via `gh pr merge --merge`.
+- **Merge SHA into feature branch:** `42109ea7d5cc1892f91c211c51df6fe30cbbfbd7`.
+- **Sub-branch closed at:** `40d612d`.
+- **Phase 4 page-level series ✅ COMPLETE** — Dashboard + Login + Register + Profile + LogFoodModal all reskinned with zero behavioral regressions. **B1 intentionally not bundled per the user's locked-in guardrail** — separate ticket in HLTH backlog. New cleanup candidate surfaced: USDA-API parens-rejection quirk (separate ticket, not in design-system migration scope).
+
+### Phase 5 — Landing polish (standalone)
+
+- **Date:** 2026-05-02
+- **Sub-branch:** `design/05-landing` cut from `feature/design-system@42109ea`. No overnight activity on main; sync gate #2 deferred to Phase 6 tomorrow per the master-agent brief (which noted PR #18 — Node 22 LTS bump — is in flight off main and will be absorbed at Phase 6 entry).
+- **Phase 5 commit:** `feat(app): Phase 5 — landing polish` (SHA appended below post-push).
+- **Pre-work verified before this phase started:** all 9 landing JSX components in `apps/web/src/components/landing/` are byte-identical to the design-system spec at `project/frontend/src/components/landing/` (HeroSection, FeaturesSection, BenefitsSection, PricingSection, Footer, LandingNavbar, BackgroundMedia, DashboardPreview, StatsBar — 0 diff lines each). So the structural reskin Phase 5 was originally framed for is already done.
+- **Files modified:**
+  - `apps/web/src/components/landing/FeaturesSection.jsx` — 1 raw span → MaterialIcon (the dynamic feature-card icon, `name={icon}`)
+  - `apps/web/src/components/landing/LandingNavbar.jsx` — 1 raw span → MaterialIcon (mobile hamburger toggle, `name={menuOpen ? 'close' : 'menu'}`); also added `aria-expanded={menuOpen}` for accessibility
+  - `apps/web/src/components/landing/DashboardPreview.jsx` — 1 raw span → MaterialIcon (`local_fire_department` in the streak card)
+  - `apps/web/src/components/landing/PricingSection.jsx` — 1 raw span → MaterialIcon (`check_circle` in feature lists, ×3 plans)
+  - `apps/web/src/components/landing/BackgroundMedia.jsx` — added `prefers-reduced-motion` autoplay suppression. Uses `window.matchMedia('(prefers-reduced-motion: reduce)')` with a live-tracking listener so OS-level toggles take effect mid-page. Falls through to poster image when reduce is set. SKILL.md non-negotiable §15 honored.
+  - `apps/web/src/index.css` — landing animation reduce-motion guards:
+    - `.landing-fade-up` duration changed from hardcoded `0.7s` to `var(--dur-reveal)` (tokens.css collapses to 0 ms on `prefers-reduced-motion: reduce`).
+    - `.landing-float` (continuous decorative idle animation) wrapped in a `@media (prefers-reduced-motion: reduce) { animation: none; }` rule so it stops entirely on reduce.
+    - `.landing-delay-1..4` zero out their delay on reduce so content appears immediately in final state without flicker.
+- **Behavior preservation (verified):**
+  - All 9 landing components functionally unchanged — same Link routes, same `BackgroundMedia` API, same `useState` mobile-menu toggle, same supabase RPC call in StatsBar, same Footer structure. Only icon swaps, autoplay-on-reduce-motion guard, and CSS animation timing changes.
+- **Primitives consumed:** `MaterialIcon` (4 usages across 4 landing files).
+- **Build:** `pnpm build` green in 3.85 s.
+- **Security gates:** `pnpm audit` clean, zero new deps, hardened secret-scan to be verified pre-push, no XSS sinks introduced (`MaterialIcon` continues to receive icon names as JSX text-children), `vercel.json` not touched, Supabase / `.env` not touched, `package.json` / `.nvmrc` not touched (PR #18 owns the Node bump off main).
+- **Token consumption audit (findings flagged for awareness — NOT fixed in this phase per scope):**
+  - **Page gutters** across landing components use raw Tailwind classes (`px-6 lg:px-10`, `max-w-7xl mx-auto`) instead of the `var(--page-gutter)` token. The token's `clamp(1rem, 4vw, 3rem)` formula doesn't cleanly substitute for the responsive `px-6 lg:px-10` pattern (which jumps from 24 px to 40 px at the lg breakpoint). The marketing page intentionally uses `max-w-7xl` (1280 px wide) which is wider than the in-app `max-w-[520px]` mobile-shaped container, so the page-gutter token's role is different here. **Conclusion: not a real gap; landing is intentionally a different layout context.** No change recommended.
+  - **Typography** uses raw Tailwind utilities (`text-3xl sm:text-4xl font-bold`, `text-xl font-semibold`, `text-xs font-semibold uppercase tracking-[0.2em]`) instead of semantic classes (`.h-display`, `.h1`, `.h2`, `.label`, `.body`, etc.) shipped in tokens.css. The semantic classes use `clamp()` for fluid type, while landing copy uses Tailwind's responsive-prefix pattern with discrete breakpoints. Either approach is valid; landing's responsive-prefix pattern gives more designer control over breakpoint behavior. **Conclusion: stylistic choice, not a regression.** Could migrate in a future structural Phase 5.5 if the design-system shifts to fluid-type-only.
+  - **Colors** mostly use Tailwind tokens (`text-white`, `text-primary`, `bg-brand-gradient`, `text-brand-cyan`, `text-brand-pink`, `bg-protein/15`, etc.) — already token-driven. No raw hex values found in landing components. ✅
+  - **One observation:** `BenefitsSection.jsx:48` uses `text-white/[0.06]` for the giant decorative number. That's an arbitrary opacity, not a token. Acceptable for a decorative numeric flourish; not flagging.
+- **SKILL.md voice rubric audit (findings flagged for awareness — NOT changed in this phase):**
+  - Sentence case: ✅ all headlines and CTAs use sentence case ("Build healthy habits", "Start tracking smarter today", "Get Started Free" — Title Case is acceptable for CTAs per the rubric's CTA pattern).
+  - Emoji rules: 1 emoji in landing — the 🚀 in the hero badge "Now Available for Web". Per SKILL.md §8 emojis are restricted to meal-types and activity-pickers. **Borderline:** the 🚀 is in a Pop badge, not a headline / CTA / celebration line. Marketing-page badge feels like a third acceptable context but it's not explicitly green-lit by the rubric. **Flagging for awareness, not fixing** — designer / marketing call.
+  - Voice (warm, data-first, second person): mostly compliant. "Lose weight with clarity" is data-first ✓. "Build healthy habits" is action-oriented ✓. Hero subheadline "Track calories, monitor nutrition, and achieve your fitness goals with intelligent insights and personalized recommendations" leans more aspirational/SaaS-marketing than data-first. **Acceptable for a marketing hero**; in-app copy follows the rubric more strictly.
+  - **Conclusion: voice is compliant enough for landing's marketing context.** No surgical edits needed.
+- **Reduce-motion audit results:**
+  - **`landing-fade-up`** (entrance fade on hero copy + dashboard preview) — now uses `var(--dur-reveal)` which collapses to 0 ms on reduce. Content appears immediately in final state. ✅
+  - **`landing-float`** (subtle bob on the right-side dashboard preview card) — now `animation: none` on reduce. Card sits still. ✅
+  - **`landing-delay-1..4`** — zero out on reduce so the staggered entrance happens instantly. ✅
+  - **`BackgroundMedia` video autoplay** — suppressed on reduce; poster image renders instead. Live media-query listener tracks runtime toggles. ✅
+  - **HeroSection / FeaturesSection / BenefitsSection / StatsBar / PricingSection / Footer / LandingNavbar** — no other animations beyond the four covered above. No scroll-triggered animations on landing currently. ✅
+  - **`celebration-enter`, `water-goal-glow`, `ring-animate`** — celebration / dashboard animations, NOT on landing. Already handled by Phase 1 motion tokens.
+- **Deltas vs. plan:**
+  - **Page-gutter token usage in landing flagged as not-applicable** rather than fixed. Landing's `max-w-7xl + px-6 lg:px-10` pattern is intentionally a different layout context (1280 px content frame for marketing) than the in-app `max-w-[520px]` mobile-shaped container (where `--page-gutter` makes more sense). Documented above; no change recommended.
+  - **Typography raw utilities flagged as stylistic, not a regression.** Could migrate in a future structural pass; not in Phase 5 scope.
+  - **🚀 emoji in hero badge flagged as borderline rubric compliance.** Not changing — designer / marketing call.
+- **Pending:** user visual + functional QA on the design/05-landing preview URL — landing renders cleanly across desktop/tablet/mobile, all 4 migrated icons visible, animations fire normally with reduce-motion OFF, animations collapse to final state with reduce-motion ON (test via macOS System Preferences → Accessibility → Display → Reduce Motion). Then merge. **After 5 lands, only Phase 6 (polish) and Phase 7 (final merge) remain.**


### PR DESCRIPTION
**Internal sub-PR — base is `feature/design-system`, NOT main.** Production untouched. Ships on top of Phase 4d merge `42109ea`.

## TL;DR

Standalone Phase 5 per the master-agent brief. **Phase 1's finding confirmed during pre-work**: all 9 landing JSX components are byte-identical to the design-system spec, so the structural reskin originally framed for Phase 5 is already done. This PR is the residual polish: icon migration + reduce-motion guards. ~30 min as estimated.

## Files changed

| File | Change |
|---|---|
| `apps/web/src/components/landing/FeaturesSection.jsx` | 1 raw span → `MaterialIcon` (dynamic feature-card icon, `name={icon}`) |
| `apps/web/src/components/landing/LandingNavbar.jsx` | 1 raw span → `MaterialIcon` (mobile hamburger, `close`/`menu`). Added `aria-expanded={menuOpen}` |
| `apps/web/src/components/landing/DashboardPreview.jsx` | 1 raw span → `MaterialIcon` (`local_fire_department` in streak card) |
| `apps/web/src/components/landing/PricingSection.jsx` | 1 raw span → `MaterialIcon` (`check_circle` ×3 in feature lists) |
| `apps/web/src/components/landing/BackgroundMedia.jsx` | Added `prefers-reduced-motion` autoplay suppression with live-tracking listener |
| `apps/web/src/index.css` | `landing-fade-up` → `var(--dur-reveal)`; `landing-float` + `landing-delay-1..4` reduce-motion overrides |

## Behavior preservation

All 9 landing components functionally unchanged. Same Link routes, same `BackgroundMedia` API, same `useState` mobile-menu toggle, same supabase RPC call in StatsBar, same Footer structure.

## Reduce-motion audit results — all 4 surfaces guarded

| Surface | Before | After |
|---|---|---|
| `landing-fade-up` (hero copy + dashboard preview entrance) | Hardcoded `0.7s` duration | `var(--dur-reveal)` — collapses to 0 ms on reduce |
| `landing-float` (subtle bob on dashboard preview card) | Always-on infinite loop | `animation: none` on reduce |
| `landing-delay-1..4` (staggered entrance) | Always 0.1/0.2/0.35/0.5s | Zero on reduce — content appears in final state instantly |
| `BackgroundMedia` video autoplay | Always autoplays muted | Suppressed on reduce — poster image renders instead. Live `matchMedia` listener tracks runtime OS-level toggles |

## QA

🔗 **Preview:** [healtho-git-design-05-landing-ayushkapoor11s-projects.vercel.app](https://healtho-git-design-05-landing-ayushkapoor11s-projects.vercel.app/)

### Visual checks
- [ ] **`/`** loads cleanly, no console errors (vercel.live block is known noise)
- [ ] **Hero** — gradient headline, dashboard preview right-side floats subtly
- [ ] **FeaturesSection** — 6 feature cards, each with icon (restaurant, monitoring, local_fire_department, water_drop, calendar_month, person)
- [ ] **BenefitsSection** — 3 numbered benefit blocks
- [ ] **PricingSection** — 3 plans (Free / Pro / Team), check_circle icons in feature lists
- [ ] **Footer** — copyright, Terms / Privacy links
- [ ] **Mobile (390 px)** — hamburger icon visible, click toggles menu (close/menu icon swap)
- [ ] **Tablet (768 px)** — layout adapts cleanly
- [ ] **Desktop (1440 px+)** — content frame at `max-w-7xl` (1280 px), centered

### Reduce-motion checks (this is the headline test)
- [ ] **macOS** → System Preferences → Accessibility → Display → **Reduce Motion ON**
- [ ] Reload `/` — hero copy + dashboard preview appear in **final state immediately**, no fade-up
- [ ] Dashboard preview card **does not bob** (landing-float suppressed)
- [ ] Hero / Features / Benefits **video backgrounds replaced with poster images** (no autoplay)
- [ ] Disable Reduce Motion → reload → all animations + video autoplay return

Or in DevTools: Rendering panel → "Emulate CSS prefers-reduced-motion" → reduce.

### Console
- [ ] No errors apart from the known `vercel.live/_next-live/feedback/feedback.js` preview-toolbar block

## Audit findings flagged for awareness (NOT fixed per scope)

1. **Page-gutter token usage:** landing's `max-w-7xl + px-6 lg:px-10` is intentionally a different layout context (1280 px marketing frame) than the in-app `max-w-[520px]` mobile-shaped container. The `--page-gutter` token doesn't map cleanly. **No change recommended.**
2. **Typography uses raw Tailwind utilities** (`text-3xl sm:text-4xl font-bold`, `text-xs font-semibold uppercase tracking-[0.2em]`) instead of semantic classes (`.h1`, `.h2`, `.label`). Stylistic choice — landing's responsive-prefix pattern gives more discrete breakpoint control than the fluid-type semantic classes. **Could migrate in a future structural pass.**
3. **🚀 emoji in hero badge** "Now Available for Web" — borderline against SKILL.md §8 (emoji restricted to meal-types and activity-pickers). Marketing-page badge feels like a third acceptable context but isn't explicitly green-lit. **Designer/marketing call.**
4. **Voice rubric** mostly compliant. Hero subheadline leans aspirational/SaaS-marketing rather than data-first. **Acceptable for a marketing hero.**

## Security gates

| Gate | Status |
|---|---|
| `pnpm audit --audit-level=high` | ✅ PASS |
| Zero new npm deps | ✅ PASS — lockfile unchanged |
| No XSS sinks | ✅ PASS |
| Hardened secret-scan | ✅ PASS |
| Same-origin assets | ✅ PASS |
| `vercel.json` untouched | ✅ PASS |
| Supabase / `.env` untouched | ✅ PASS |
| `package.json` / `.nvmrc` untouched | ✅ PASS — PR #18 owns the Node 22 LTS bump off main |

## Phase 4d closeout (rides on this PR's log commit)

PR #17 merge SHA `42109ea` + user QA result + USDA-parens-rejection note (verified pre-existing API quirk, not a Phase 4d regression) appended to `docs/design-system-execution-plan.md`. **Phase 4 page-level series ✅ COMPLETE.**

## Note on PR #18 (in flight off main)

The Node 22 LTS bump is on its own branch off main with zero overlap with these landing files. Sync gate #2 to absorb it into `feature/design-system` is scheduled for tomorrow's Phase 6 entry per the master-agent brief.

## Known QA noise (NOT a regression)

`vercel.live/_next-live/feedback/feedback.js` CSP block on previews — pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)