### PR TITLE
Phase 6: polish (auth-tail icons + CSP cleanup + reduce-motion audit + validation sweep)

### DIFF
--- a/apps/web/src/components/LogFoodModal.jsx
+++ b/apps/web/src/components/LogFoodModal.jsx
@@ -585,7 +585,7 @@ export default function LogFoodModal({ open, defaultMeal = null, logDate, editEn
       className={`fixed inset-0 bg-black/60 z-50 flex items-end justify-center transition-opacity duration-200 ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
       onClick={handleOverlay}
     >
-      <div className={`w-full max-w-[520px] bg-[#1a1a1a] border border-slate-800 rounded-t-2xl p-5 pb-10 max-h-[90vh] overflow-y-auto scrollbar-hide transition-transform duration-300 ${open ? 'translate-y-0' : 'translate-y-full'}`}>
+      <div className={`w-full max-w-[520px] bg-[#1a1a1a] border border-slate-800 rounded-t-2xl p-5 pb-10 max-h-[90vh] overflow-y-auto scrollbar-hide transition-transform duration-300 motion-reduce:transition-none ${open ? 'translate-y-0' : 'translate-y-full'}`}>
 
         <div className="w-10 h-1 rounded-full bg-slate-700 mx-auto mb-5" />
         <h2 className="text-white text-2xl font-extrabold mb-1">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -24,6 +24,9 @@
 .ring-animate {
   animation: ringFill 1.4s cubic-bezier(.16, 1, .3, 1) both;
 }
+@media (prefers-reduced-motion: reduce) {
+  .ring-animate { animation: none; stroke-dashoffset: 101.8; }
+}
 
 /* ── Brand gradient utilities ─────────────────────────────── */
 .bg-brand-gradient {
@@ -82,6 +85,9 @@
 .celebration-enter {
   animation: celebrationFadeIn 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
+@media (prefers-reduced-motion: reduce) {
+  .celebration-enter { animation: none; opacity: 1; transform: none; }
+}
 
 @keyframes waterGlow {
   0%, 100% { box-shadow: 0 0 15px rgba(96, 184, 212, 0.3), inset 0 0 15px rgba(96, 184, 212, 0.05); }
@@ -92,4 +98,9 @@
   animation: waterGlow 2s ease-in-out infinite;
   border-color: #60b8d4 !important;
   background: linear-gradient(135deg, rgba(96, 184, 212, 0.08) 0%, rgba(14, 11, 30, 1) 100%) !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Suppress the infinite glow loop entirely; static border + bg still convey
+     goal-met state without vestibular trigger. */
+  .water-goal-glow { animation: none; }
 }

--- a/apps/web/src/pages/AuthCallback.jsx
+++ b/apps/web/src/pages/AuthCallback.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 import { supabase } from '../lib/supabase'
 
 /**
@@ -63,7 +64,7 @@ export default function AuthCallback() {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background-dark px-4">
         <div className="text-center space-y-4">
-          <span className="material-symbols-outlined text-red-400 text-5xl">error</span>
+          <MaterialIcon name="error" size={48} className="text-red-400" />
           <p className="text-red-400 font-semibold">{error}</p>
           <button
             onClick={() => navigate('/login')}
@@ -80,9 +81,7 @@ export default function AuthCallback() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-background-dark">
       <div className="flex flex-col items-center gap-4">
-        <span className="material-symbols-outlined animate-spin text-primary text-4xl">
-          progress_activity
-        </span>
+        <MaterialIcon name="progress_activity" size={36} className="animate-spin text-primary" />
         <p className="text-slate-500 text-sm font-semibold">Signing you in…</p>
       </div>
     </div>

--- a/apps/web/src/pages/ForgotPassword.jsx
+++ b/apps/web/src/pages/ForgotPassword.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 import Header from '../components/Header'
 import { supabase } from '../lib/supabase'
 
@@ -7,7 +8,7 @@ function FieldError({ message }) {
   if (!message) return null
   return (
     <p className="flex items-center gap-1.5 text-red-400 text-xs font-semibold mt-1">
-      <span className="material-symbols-outlined text-sm">error</span>
+      <MaterialIcon name="error" size={14} />
       {message}
     </p>
   )
@@ -51,7 +52,7 @@ export default function ForgotPassword() {
             /* ── Success state ── */
             <div className="text-center">
               <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-6">
-                <span className="material-symbols-outlined text-primary text-3xl">mark_email_read</span>
+                <MaterialIcon name="mark_email_read" size={28} className="text-primary" />
               </div>
               <h1 className="text-white text-3xl font-extrabold mb-3">Check your inbox</h1>
               <p className="text-slate-400 text-base mb-2">
@@ -72,7 +73,7 @@ export default function ForgotPassword() {
                   to="/login"
                   className="w-full h-12 flex items-center justify-center gap-2 text-primary text-sm font-semibold hover:underline"
                 >
-                  <span className="material-symbols-outlined text-base">arrow_back</span>
+                  <MaterialIcon name="arrow_back" size={16} />
                   Back to login
                 </Link>
               </div>
@@ -92,7 +93,7 @@ export default function ForgotPassword() {
               <div className="space-y-5">
                 <div className="flex flex-col gap-1">
                   <label className="text-slate-300 text-sm font-semibold flex items-center gap-2 mb-1">
-                    <span className="material-symbols-outlined text-primary text-xl">mail</span>
+                    <MaterialIcon name="mail" size={20} className="text-primary" />
                     Email
                   </label>
                   <input
@@ -117,13 +118,13 @@ export default function ForgotPassword() {
                 >
                   {loading ? (
                     <>
-                      <span className="material-symbols-outlined animate-spin text-xl">progress_activity</span>
+                      <MaterialIcon name="progress_activity" size={20} className="animate-spin" />
                       Sending…
                     </>
                   ) : (
                     <>
                       Send reset link
-                      <span className="material-symbols-outlined transition-transform group-hover:translate-x-1">arrow_forward</span>
+                      <MaterialIcon name="arrow_forward" size={20} className="transition-transform group-hover:translate-x-1" />
                     </>
                   )}
                 </button>

--- a/apps/web/src/pages/NotFound.jsx
+++ b/apps/web/src/pages/NotFound.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 import Header from '../components/Header'
 
 export default function NotFound() {
@@ -17,7 +18,7 @@ export default function NotFound() {
           {/* Icon */}
           <div className="flex justify-center mb-6 -mt-4">
             <div className="w-20 h-20 rounded-full bg-slate-900 border border-slate-800 flex items-center justify-center">
-              <span className="material-symbols-outlined text-primary text-4xl">search_off</span>
+              <MaterialIcon name="search_off" size={36} className="text-primary" />
             </div>
           </div>
 
@@ -36,14 +37,14 @@ export default function NotFound() {
               to="/dashboard"
               className="w-full h-14 bg-primary hover:bg-primary-dark text-white rounded-xl font-bold text-lg shadow-lg shadow-primary/20 transition-all flex items-center justify-center gap-2 group"
             >
-              <span className="material-symbols-outlined">home</span>
+              <MaterialIcon name="home" size={20} />
               Go to Dashboard
             </Link>
             <Link
               to="/login"
               className="w-full h-12 rounded-xl border border-slate-800 bg-slate-900 hover:bg-slate-800 text-slate-300 font-semibold text-base transition-colors flex items-center justify-center gap-2"
             >
-              <span className="material-symbols-outlined text-xl">login</span>
+              <MaterialIcon name="login" size={20} />
               Back to Login
             </Link>
           </div>
@@ -62,9 +63,9 @@ export default function NotFound() {
                   key={to} to={to}
                   className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-slate-800 transition-colors group"
                 >
-                  <span className="material-symbols-outlined text-primary text-base">{icon}</span>
+                  <MaterialIcon name={icon} size={16} className="text-primary" />
                   <span className="text-slate-300 text-sm font-semibold group-hover:text-white transition-colors">{label}</span>
-                  <span className="material-symbols-outlined text-slate-700 text-sm ml-auto group-hover:text-slate-500 transition-colors">arrow_forward</span>
+                  <MaterialIcon name="arrow_forward" size={14} className="text-slate-700 ml-auto group-hover:text-slate-500 transition-colors" />
                 </Link>
               ))}
             </div>

--- a/apps/web/src/pages/Privacy.jsx
+++ b/apps/web/src/pages/Privacy.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 import Header from '../components/Header'
 
 const SECTIONS = [
@@ -60,7 +61,7 @@ export default function Privacy() {
           {/* Heading */}
           <div className="mb-10">
             <div className="inline-flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-full px-4 py-1.5 mb-4">
-              <span className="material-symbols-outlined text-primary text-base">shield</span>
+              <MaterialIcon name="shield" size={16} className="text-primary" />
               <span className="text-primary text-xs font-bold uppercase tracking-wider">Legal</span>
             </div>
             <h1 className="text-white text-4xl font-extrabold leading-tight tracking-tight">
@@ -82,7 +83,7 @@ export default function Privacy() {
               <div key={i} className="bg-slate-900 border border-slate-800 rounded-xl p-6">
                 <div className="flex items-start gap-3 mb-3">
                   <div className="flex-shrink-0 w-9 h-9 rounded-xl bg-primary/10 flex items-center justify-center mt-0.5">
-                    <span className="material-symbols-outlined text-primary text-lg">{s.icon}</span>
+                    <MaterialIcon name={s.icon} size={18} className="text-primary" />
                   </div>
                   <h2 className="text-white text-lg font-bold pt-1">{s.title}</h2>
                 </div>
@@ -97,7 +98,7 @@ export default function Privacy() {
               to="/register"
               className="inline-flex items-center gap-2 text-primary text-sm font-semibold hover:underline"
             >
-              <span className="material-symbols-outlined text-base">arrow_back</span>
+              <MaterialIcon name="arrow_back" size={16} />
               Back to registration
             </Link>
           </div>

--- a/apps/web/src/pages/ResetPassword.jsx
+++ b/apps/web/src/pages/ResetPassword.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 import Header from '../components/Header'
 import { supabase } from '../lib/supabase'
 
@@ -7,7 +8,7 @@ function FieldError({ message }) {
   if (!message) return null
   return (
     <p className="flex items-center gap-1.5 text-red-400 text-xs font-semibold mt-1">
-      <span className="material-symbols-outlined text-sm">error</span>
+      <MaterialIcon name="error" size={14} />
       {message}
     </p>
   )
@@ -81,7 +82,7 @@ export default function ResetPassword() {
       <main className="flex-1 flex items-center justify-center px-4 py-12">
         <div className="w-full max-w-[520px] text-center">
           <div className="w-16 h-16 rounded-full bg-green-500/10 flex items-center justify-center mx-auto mb-6">
-            <span className="material-symbols-outlined text-green-400 text-3xl">check_circle</span>
+            <MaterialIcon name="check_circle" size={28} className="text-green-400" />
           </div>
           <h1 className="text-white text-3xl font-extrabold mb-3">Password updated!</h1>
           <p className="text-slate-400 text-base mb-8">
@@ -102,7 +103,7 @@ export default function ResetPassword() {
       <main className="flex-1 flex items-center justify-center px-4 py-12">
         <div className="w-full max-w-[520px] text-center">
           <div className="w-16 h-16 rounded-full bg-red-500/10 flex items-center justify-center mx-auto mb-6">
-            <span className="material-symbols-outlined text-red-400 text-3xl">link_off</span>
+            <MaterialIcon name="link_off" size={28} className="text-red-400" />
           </div>
           <h1 className="text-white text-3xl font-extrabold mb-3">Link expired</h1>
           <p className="text-slate-400 text-base mb-8">
@@ -112,7 +113,7 @@ export default function ResetPassword() {
             to="/forgot-password"
             className="inline-flex items-center gap-2 h-12 px-6 bg-primary hover:bg-primary-dark text-white rounded-xl font-semibold text-sm transition-colors"
           >
-            <span className="material-symbols-outlined text-base">send</span>
+            <MaterialIcon name="send" size={16} />
             Request new link
           </Link>
         </div>
@@ -126,7 +127,7 @@ export default function ResetPassword() {
       <Header />
       <main className="flex-1 flex items-center justify-center px-4">
         <div className="flex flex-col items-center gap-4">
-          <span className="material-symbols-outlined text-primary text-4xl animate-spin">progress_activity</span>
+          <MaterialIcon name="progress_activity" size={36} className="text-primary animate-spin" />
           <p className="text-slate-400 text-sm">Verifying reset link…</p>
         </div>
       </main>
@@ -155,7 +156,7 @@ export default function ResetPassword() {
             {/* New password */}
             <div className="flex flex-col gap-1">
               <label className="text-slate-300 text-sm font-semibold flex items-center gap-2 mb-1">
-                <span className="material-symbols-outlined text-primary text-xl">lock</span>
+                <MaterialIcon name="lock" size={20} className="text-primary" />
                 New Password
               </label>
               <div className="relative">
@@ -176,7 +177,7 @@ export default function ResetPassword() {
                   onClick={() => setShowPw(v => !v)}
                   className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300 transition-colors"
                 >
-                  <span className="material-symbols-outlined text-xl">{showPw ? 'visibility_off' : 'visibility'}</span>
+                  <MaterialIcon name={showPw ? 'visibility_off' : 'visibility'} size={20} />
                 </button>
               </div>
               <FieldError message={errors.password} />
@@ -185,7 +186,7 @@ export default function ResetPassword() {
             {/* Confirm password */}
             <div className="flex flex-col gap-1">
               <label className="text-slate-300 text-sm font-semibold flex items-center gap-2 mb-1">
-                <span className="material-symbols-outlined text-primary text-xl">lock_reset</span>
+                <MaterialIcon name="lock_reset" size={20} className="text-primary" />
                 Confirm Password
               </label>
               <input
@@ -206,7 +207,7 @@ export default function ResetPassword() {
             {/* General error */}
             {errors.general && (
               <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-xl">
-                <span className="material-symbols-outlined text-red-400 text-base">warning</span>
+                <MaterialIcon name="warning" size={16} className="text-red-400" />
                 <p className="text-red-400 text-sm font-semibold">{errors.general}</p>
               </div>
             )}
@@ -218,13 +219,13 @@ export default function ResetPassword() {
             >
               {loading ? (
                 <>
-                  <span className="material-symbols-outlined animate-spin text-xl">progress_activity</span>
+                  <MaterialIcon name="progress_activity" size={20} className="animate-spin" />
                   Updating…
                 </>
               ) : (
                 <>
                   Update password
-                  <span className="material-symbols-outlined transition-transform group-hover:translate-x-1">arrow_forward</span>
+                  <MaterialIcon name="arrow_forward" size={20} className="transition-transform group-hover:translate-x-1" />
                 </>
               )}
             </button>

--- a/apps/web/src/pages/Terms.jsx
+++ b/apps/web/src/pages/Terms.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { MaterialIcon } from '@healtho/ui'
 import Header from '../components/Header'
 
 const SECTIONS = [
@@ -59,7 +60,7 @@ export default function Terms() {
           {/* Heading */}
           <div className="mb-10">
             <div className="inline-flex items-center gap-2 bg-primary/10 border border-primary/20 rounded-full px-4 py-1.5 mb-4">
-              <span className="material-symbols-outlined text-primary text-base">gavel</span>
+              <MaterialIcon name="gavel" size={16} className="text-primary" />
               <span className="text-primary text-xs font-bold uppercase tracking-wider">Legal</span>
             </div>
             <h1 className="text-white text-4xl font-extrabold leading-tight tracking-tight">
@@ -96,7 +97,7 @@ export default function Terms() {
               to="/register"
               className="inline-flex items-center gap-2 text-primary text-sm font-semibold hover:underline"
             >
-              <span className="material-symbols-outlined text-base">arrow_back</span>
+              <MaterialIcon name="arrow_back" size={16} />
               Back to registration
             </Link>
           </div>

--- a/docs/design-system-execution-plan.md
+++ b/docs/design-system-execution-plan.md
@@ -1017,3 +1017,78 @@ Per-phase record. Each entry captures: merge SHA into `feature/design-system`, V
   - **Typography raw utilities flagged as stylistic, not a regression.** Could migrate in a future structural pass; not in Phase 5 scope.
   - **🚀 emoji in hero badge flagged as borderline rubric compliance.** Not changing — designer / marketing call.
 - **Pending:** user visual + functional QA on the design/05-landing preview URL — landing renders cleanly across desktop/tablet/mobile, all 4 migrated icons visible, animations fire normally with reduce-motion OFF, animations collapse to final state with reduce-motion ON (test via macOS System Preferences → Accessibility → Display → Reduce Motion). Then merge. **After 5 lands, only Phase 6 (polish) and Phase 7 (final merge) remain.**
+- **Closeout:**
+  - **Phase 5 commit SHA:** `5442745` (`feat(app): Phase 5 — landing polish (4 icons + reduce-motion guards)`)
+  - **PR #19** merged into `feature/design-system` at `b1e8800` ("Merge pull request #19 from healtho-app/design/05-landing"). User QA passed — landing renders correctly across viewports, reduce-motion guards behave as expected.
+  - **Audit-of-the-audit (correction surfaced during Phase 6 prep):** the Phase 5 closeout note above stated `celebration-enter`, `water-goal-glow`, and `ring-animate` were "Already handled by Phase 1 motion tokens." That claim is inaccurate — those three classes use **hardcoded** durations (`0.4s`, `2s ... infinite`, `1.4s`) and do NOT consume `var(--dur-*)` tokens. Phase 1's tokens.css `prefers-reduced-motion` block only zeroes the `--dur-*` custom properties; it cannot touch hardcoded animation shorthands. Phase 6 closes this gap (see Phase 6 entry below).
+
+### Phase 6 — Polish (auth-tail icons + CSP cleanup + reduce-motion audit + validation sweep)
+
+- **Date:** 2026-04-30 (today)
+- **Sub-branch:** `design/06-polish` cut from `feature/design-system@b1e8800`.
+- **Sync gate #2:** **skipped** — `origin/main` still at `efafab8` (PR #18 — Node 22 LTS bump — not yet merged off main per master-agent brief). Per dispatch instruction: "Sync gate #2 will run separately before Phase 7 dispatch." `git log origin/main` confirms no new commits since the last sync gate snapshot.
+
+#### Bucket 1 — Auth-tail / utility icon migration (raw `<span class="material-symbols-outlined">` → `<MaterialIcon />`)
+
+Six pages migrated. Each gained an `import { MaterialIcon } from '@healtho/ui'` and had every raw icon span swapped 1-for-1. No prop / callback / Supabase call changes. Behavioral preservation verified by diff inspection.
+
+- `apps/web/src/pages/ForgotPassword.jsx` — 6 spans → MaterialIcon (`error`, `mark_email_read`, `arrow_back`, `mail`, `progress_activity` ×2, `arrow_forward`)
+- `apps/web/src/pages/ResetPassword.jsx` — 11 spans → MaterialIcon (`error`, `check_circle`, `link_off`, `send`, `progress_activity` (verify), `lock`, dynamic `visibility`/`visibility_off`, `lock_reset`, `warning`, `progress_activity` (button), `arrow_forward`)
+- `apps/web/src/pages/AuthCallback.jsx` — 2 spans → MaterialIcon (`error`, `progress_activity` with `animate-spin`)
+- `apps/web/src/pages/NotFound.jsx` — 5 spans → MaterialIcon (`search_off`, `home`, `login`, dynamic `{icon}` in quick-links, `arrow_forward`)
+- `apps/web/src/pages/Terms.jsx` — 2 spans → MaterialIcon (`gavel`, `arrow_back`)
+- `apps/web/src/pages/Privacy.jsx` — 3 spans → MaterialIcon (`shield`, dynamic `{s.icon}` in section list, `arrow_back`)
+
+After this bucket, **zero** raw `material-symbols-outlined` spans remain across `apps/web/src/`.
+
+#### Bucket 2 — `vercel.json` CSP cleanup (Pickup D, pre-approved)
+
+Locked-in change per the master-agent brief — no other CSP directives touched:
+
+- `style-src`: removed `https://fonts.googleapis.com` (kept `https://fonts.googleapis.com/css2` since the import path uses the full URL with the `/css2` segment)
+- `font-src`: removed `https://fonts.gstatic.com` (we now self-host all fonts — Lexend, DM Mono, Material Symbols Outlined — via `packages/ui/fonts/` so the gstatic CDN allow-list is dead weight)
+- All other directives byte-identical: `default-src`, `script-src`, `worker-src`, `connect-src`, `img-src`, `frame-ancestors`
+
+Reasoning: closing the door on third-party font CDN connections matches the self-hosted-font reality from Phase 1 and Phase 3d. CSP attack surface shrinks. The Network tab on a freshly-loaded preview page should show **zero** requests to `fonts.googleapis.com` or `fonts.gstatic.com` — if any appear, that's a regression to investigate.
+
+(First-attempt over-broad edit was self-caught and reverted before commit; final value matches the brief precisely.)
+
+#### Bucket 3 — `prefers-reduced-motion` full-app audit
+
+Audit found **three** custom CSS animations in `apps/web/src/index.css` whose `animation` shorthand uses hardcoded durations (`0.4s`, `1.4s`, `2s ... infinite`) and therefore are NOT covered by tokens.css's `--dur-*` collapse rule. Each is now wrapped in a per-class `@media (prefers-reduced-motion: reduce)` override:
+
+- `.ring-animate` — `animation: none` + freezes `stroke-dashoffset` at the end-of-animation value (101.8) so the calorie ring renders in its filled final state without the 1.4 s sweep.
+- `.celebration-enter` — `animation: none` + `opacity: 1; transform: none;` so the celebration card appears in its final position immediately, no fade-and-scale.
+- `.water-goal-glow` — `animation: none`. **Critical:** this one is an INFINITE loop (`waterGlow 2s ease-in-out infinite`) — the most clearly vestibular-sensitive animation in the codebase. Static cyan border + gradient still convey goal-met state without the pulsing glow.
+
+`apps/web/src/components/LogFoodModal.jsx:588` — full-screen bottom-sheet slide-up uses `transition-transform duration-300` plus `${open ? 'translate-y-0' : 'translate-y-full'}`. That's a full-viewport-height translate — the largest single motion in the app outside the celebration overlay. Added `motion-reduce:transition-none` so the modal snaps into place instead of sliding when reduce-motion is on.
+
+Token-driven animations verified safe (no change needed):
+- `CalorieRing.jsx:157` reward state — `animation: 'rewardPop var(--dur-reward) var(--ease-spring) both'` ✅
+- `CelebrationOverlay.jsx:166,177,203` — `rewardBurst`, `rewardPop`, `rewardShimmer` all reference `var(--dur-reward)` ✅
+- `index.css` `.landing-fade-up` — `var(--dur-reveal)` (Phase 5) ✅
+- `index.css` `.landing-float` — `animation: none` reduce-motion override (Phase 5) ✅
+- `BackgroundMedia` video — autoplay suppressed with poster fallback (Phase 5) ✅
+
+Tailwind `animate-spin` / `animate-pulse` (loading spinners + skeleton) intentionally **not** disabled — they convey active loading state, removing them would make UI appear frozen. Per WCAG 2.3.3 these are functional indicators, not decorative motion.
+
+Tailwind `transition-colors` / `transition-opacity` / short hover transforms (`hover:-translate-y-0.5` ~2 px, `duration-200`) intentionally **not** disabled — these are sub-vestibular-threshold cosmetic state changes, not large translates / parallax / infinite loops.
+
+#### Bucket 4 — Final validation sweep
+
+- **`pnpm turbo run build --filter=healtho-web`:** ✅ green in 3.50 s. 511 modules transformed. Bundle warning about 598 kB main chunk is pre-existing (not introduced by Phase 6).
+- **`pnpm audit --prod`:** ✅ "No known vulnerabilities found"
+- **Hardened secret-scan** (credential-shape pattern across the repo, excluding node_modules / dist / .git / .turbo / build / .next / .vercel): ✅ no matches
+- **`vercel.json` final CSP value:** verified byte-precise match to brief
+- **No new dependencies:** ✅ no `package.json` changes in Phase 6
+- **Supabase / `.env`:** ✅ untouched
+- **`packages/ui` source:** ✅ untouched (only `apps/web/src/` modified for the icon swaps + index.css guards)
+- **Lighthouse + console-clean smoke + Network-tab third-party-font check:** to be performed by user on the design/06-polish Vercel preview URL.
+
+#### Working-tree summary at PR-prep time
+
+9 modified files: `apps/web/src/components/LogFoodModal.jsx`, `apps/web/src/index.css`, `apps/web/src/pages/AuthCallback.jsx`, `apps/web/src/pages/ForgotPassword.jsx`, `apps/web/src/pages/NotFound.jsx`, `apps/web/src/pages/Privacy.jsx`, `apps/web/src/pages/ResetPassword.jsx`, `apps/web/src/pages/Terms.jsx`, `vercel.json`.
+
+#### Pending
+
+User QA on the design/06-polish Vercel preview URL (validation sweep items above + visual). After QA approval: merge PR #20 into `feature/design-system`. Then **only Phase 7 (final merge to main) remains**, gated by sync gate #2 to absorb PR #18 once it lands on main.

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.googleapis.com/css2; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.nal.usda.gov; img-src 'self' data: https:; frame-ancestors 'none';" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://fonts.googleapis.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css2; font-src 'self'; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.nal.usda.gov; img-src 'self' data: https:; frame-ancestors 'none';" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Phase 6 of the design-system migration — final polish before the Phase 7 merge to main.

**Bucket 1 — Auth-tail icon migration.** Six pages migrated raw \`<span class=\"material-symbols-outlined\">\` → \`<MaterialIcon />\`: ForgotPassword (6), ResetPassword (11), AuthCallback (2), NotFound (5), Terms (2), Privacy (3). **Zero raw icon spans remain in \`apps/web/src/\`.**

**Bucket 2 — \`vercel.json\` CSP cleanup (Pickup D, pre-approved).** Drop two now-unused third-party font CDN entries:
- \`style-src\`: removed \`https://fonts.googleapis.com\` (kept \`https://fonts.googleapis.com/css2\` since the import path uses the full \`/css2\` URL)
- \`font-src\`: removed \`https://fonts.gstatic.com\`

All fonts are self-hosted out of \`packages/ui/fonts/\` since Phase 1 + Phase 3d. All other CSP directives byte-identical.

**Bucket 3 — \`prefers-reduced-motion\` full-app audit.** Found 3 custom CSS animations in \`index.css\` whose \`animation\` shorthand uses hardcoded durations and therefore bypass tokens.css's \`--dur-*\` collapse rule. Each now has a per-class \`@media (prefers-reduced-motion: reduce)\` override:
- \`.ring-animate\` — \`animation: none\` + freeze \`stroke-dashoffset: 101.8\` (calorie ring snaps to filled final state)
- \`.celebration-enter\` — \`animation: none\` + \`opacity: 1; transform: none\` (celebration card appears in place)
- \`.water-goal-glow\` — \`animation: none\` (kills the infinite 2 s glow loop — most clearly vestibular-sensitive)

\`LogFoodModal.jsx\` full-screen slide-up gains \`motion-reduce:transition-none\` so the modal snaps instead of sliding.

\`animate-spin\` / \`animate-pulse\` (loading spinners + skeletons) intentionally NOT disabled — they convey active loading state per WCAG 2.3.3.

**Bucket 4 — Final validation sweep.** \`pnpm build\` ✅ green in 3.50 s; \`pnpm audit --prod\` ✅ no known vulnerabilities; hardened secret-scan ✅ clean; no new deps; \`packages/ui\` / Supabase / \`.env\` untouched.

**Sync gate #2:** **skipped** — \`origin/main\` still at \`efafab8\` (PR #18 — Node 22 LTS bump — not yet merged off main). Per dispatch: sync gate #2 will run separately before Phase 7.

After this lands: only Phase 7 (final merge to main) remains.

## Test plan

- [ ] Vercel preview boots cleanly; \`/\`, \`/login\`, \`/register\`, \`/dashboard\`, \`/profile\`, \`/forgot-password\`, \`/reset-password\`, \`/404\`, \`/terms\`, \`/privacy\`, \`/auth/callback\` all render
- [ ] Network tab on a fresh hard-reload of any preview page shows **zero** requests to \`fonts.googleapis.com\` or \`fonts.gstatic.com\` (CSP cleanup proof)
- [ ] All 6 auth-tail / utility pages: every icon renders identically to before; loading spinners spin, error states show error icon, etc.
- [ ] LogFoodModal opens and closes — slides up + fades overlay normally with reduce-motion OFF
- [ ] **Reduce-motion ON test** (macOS: System Preferences → Accessibility → Display → Reduce Motion):
  - Calorie ring renders fully filled immediately (no 1.4 s sweep)
  - Celebration overlay (trigger by hitting your daily calorie goal) appears in place (no fade+scale)
  - Water tracker goal-met glow stays static (no pulsing)
  - LogFoodModal snaps open instead of sliding
  - Landing page hero copy appears in final position (Phase 5 guards still working)
  - BackgroundMedia video poster still renders without autoplay (Phase 5 guard still working)
- [ ] Dashboard / LogFoodModal flows still work (search USDA item, add to meal, edit existing entry, delete, save-as-favorite, log custom food)
- [ ] Console clean across all routes — no warnings / errors
- [ ] Lighthouse perf vs production main remains comparable (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)